### PR TITLE
Fix consumer role handling for new request access

### DIFF
--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -26,7 +26,7 @@ router.post('/register', async (req, res) => {
     return res.status(503).json({ message: 'Database is not ready yet. Please try again.' });
   }
 
-  const { name, email, password, role = 'customer' } = req.body ?? {};
+  const { name, email, password, role = 'consumer' } = req.body ?? {};
 
   if (!name || !email || !password) {
     return res.status(400).json({ message: 'Name, email and password are required.' });

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -12,6 +12,17 @@ const initialState = {
   error: null
 };
 
+const normaliseUser = (user) => {
+  if (!user) {
+    return user;
+  }
+
+  return {
+    ...user,
+    role: user.role === 'customer' ? 'consumer' : user.role
+  };
+};
+
 const authReducer = (state, action) => {
   switch (action.type) {
     case 'LOGIN_START':
@@ -39,10 +50,11 @@ export const AuthProvider = ({ children }) => {
 
     try {
       const user = await apiClient.post('/auth/login', { email, password });
+      const normalisedUser = normaliseUser(user);
 
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(user));
-      dispatch({ type: 'LOGIN_SUCCESS', payload: user });
-      return user;
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(normalisedUser));
+      dispatch({ type: 'LOGIN_SUCCESS', payload: normalisedUser });
+      return normalisedUser;
     } catch (error) {
       dispatch({
         type: 'LOGIN_FAILURE',
@@ -57,10 +69,11 @@ export const AuthProvider = ({ children }) => {
 
     try {
       const user = await apiClient.post('/auth/register', userData);
+      const normalisedUser = normaliseUser(user);
 
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(user));
-      dispatch({ type: 'LOGIN_SUCCESS', payload: user });
-      return user;
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(normalisedUser));
+      dispatch({ type: 'LOGIN_SUCCESS', payload: normalisedUser });
+      return normalisedUser;
     } catch (error) {
       dispatch({
         type: 'LOGIN_FAILURE',
@@ -86,8 +99,9 @@ export const AuthProvider = ({ children }) => {
     if (storedUser) {
       try {
         const parsedUser = JSON.parse(storedUser);
+        const normalisedUser = normaliseUser(parsedUser);
         if (parsedUser) {
-          dispatch({ type: 'LOGIN_SUCCESS', payload: parsedUser });
+          dispatch({ type: 'LOGIN_SUCCESS', payload: normalisedUser });
         }
       } catch (error) {
         console.error('Failed to parse stored user data', error);


### PR DESCRIPTION
## Summary
- normalise stored user roles in the auth context so legacy "customer" accounts are treated as consumers on the client
- update the server registration default role to "consumer" to align with front-end protected route checks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbdac819bc8321b50209e38b574817