### PR TITLE
Persist new delivery requests to Mongo

### DIFF
--- a/server/routes/deliveryRequests.js
+++ b/server/routes/deliveryRequests.js
@@ -187,7 +187,8 @@ router.post('/', async (req, res) => {
       deliveryCharge: paymentDetails.deliveryCharge ?? 0,
       gst: paymentDetails.gst ?? 0,
       totalAmount: paymentDetails.totalAmount ?? 0,
-      paymentStatus: paymentDetails.paymentStatus ?? 'pending'
+      paymentStatus: paymentDetails.paymentStatus ?? 'pending',
+      paymentMethod: paymentDetails.paymentMethod ?? 'card'
     },
     createdAt: now,
     updatedAt: now
@@ -315,19 +316,38 @@ router.patch('/:id/payment', async (req, res) => {
 
   const now = new Date();
 
+  const updateSet = {
+    'paymentDetails.paymentStatus': paymentStatus,
+    updatedAt: now
+  };
+
+  if (paymentDetails.baseHandlingFee !== undefined) {
+    updateSet['paymentDetails.baseHandlingFee'] = paymentDetails.baseHandlingFee;
+  }
+
+  if (paymentDetails.storageFee !== undefined) {
+    updateSet['paymentDetails.storageFee'] = paymentDetails.storageFee;
+  }
+
+  if (paymentDetails.deliveryCharge !== undefined) {
+    updateSet['paymentDetails.deliveryCharge'] = paymentDetails.deliveryCharge;
+  }
+
+  if (paymentDetails.gst !== undefined) {
+    updateSet['paymentDetails.gst'] = paymentDetails.gst;
+  }
+
+  if (paymentDetails.totalAmount !== undefined) {
+    updateSet['paymentDetails.totalAmount'] = paymentDetails.totalAmount;
+  }
+
+  if (paymentDetails.paymentMethod !== undefined) {
+    updateSet['paymentDetails.paymentMethod'] = paymentDetails.paymentMethod;
+  }
+
   const updateResult = await db.collection('deliveryRequests').findOneAndUpdate(
     { _id: requestId },
-    {
-      $set: {
-        'paymentDetails.paymentStatus': paymentStatus,
-        'paymentDetails.baseHandlingFee': paymentDetails.baseHandlingFee,
-        'paymentDetails.storageFee': paymentDetails.storageFee,
-        'paymentDetails.deliveryCharge': paymentDetails.deliveryCharge,
-        'paymentDetails.gst': paymentDetails.gst,
-        'paymentDetails.totalAmount': paymentDetails.totalAmount,
-        updatedAt: now
-      }
-    },
+    { $set: updateSet },
     { returnDocument: 'after' }
   );
 

--- a/src/pages/Request/NewRequest.jsx
+++ b/src/pages/Request/NewRequest.jsx
@@ -1,8 +1,10 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Upload, Calendar, CreditCard } from 'lucide-react';
 import WarehouseMap from '../../components/Map/WarehouseMap';
 import { ecommercePlatforms, timeSlots } from '../../data/mockData';
+import apiClient from '../../lib/api';
+import { useAuth } from '../../context/AuthContext';
 
 const initialFormData = {
   orderNumber: '',
@@ -23,12 +25,34 @@ const initialFormData = {
   }
 };
 
+const calculateCharges = () => {
+  const baseHandlingFee = 49;
+  const storageFee = 20;
+  const deliveryCharge = 60;
+  const subtotal = baseHandlingFee + storageFee + deliveryCharge;
+  const gst = subtotal * 0.18;
+  const total = subtotal + gst;
+
+  return {
+    baseHandlingFee,
+    storageFee,
+    deliveryCharge,
+    subtotal,
+    gst,
+    total
+  };
+};
+
 const NewRequest = () => {
   const navigate = useNavigate();
+  const { state } = useAuth();
   const [currentStep, setCurrentStep] = useState(1);
   const [formData, setFormData] = useState(initialFormData);
   const [selectedFile, setSelectedFile] = useState(null);
   const [errors, setErrors] = useState({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState(null);
+  const [selectedPaymentMethod, setSelectedPaymentMethod] = useState('card');
 
   const handleInputChange = (event) => {
     const { name, value } = event.target;
@@ -103,37 +127,80 @@ const NewRequest = () => {
 
   const handleNext = () => {
     if (currentStep === 1 && validateStep1()) {
+      setSubmitError(null);
       setCurrentStep(2);
     } else if (currentStep === 2 && validateStep2()) {
+      setSubmitError(null);
       setCurrentStep(3);
     }
   };
 
-  const handleSubmit = () => {
-    setTimeout(() => {
-      navigate('/dashboard');
-    }, 1000);
-  };
+  const charges = useMemo(() => calculateCharges(), []);
 
-  const calculateCharges = () => {
-    const baseHandlingFee = 49;
-    const storageFee = 20;
-    const deliveryCharge = 60;
-    const subtotal = baseHandlingFee + storageFee + deliveryCharge;
-    const gst = subtotal * 0.18;
-    const total = subtotal + gst;
+  const handleSubmit = async () => {
+    if (isSubmitting) {
+      return;
+    }
 
-    return {
-      baseHandlingFee,
-      storageFee,
-      deliveryCharge,
-      subtotal,
-      gst,
-      total
+    if (!state.user?.id) {
+      setSubmitError('You need to be logged in to create a delivery request.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setSubmitError(null);
+
+    const normalisedAddress = {
+      line1: formData.destinationAddress.line1.trim(),
+      line2: formData.destinationAddress.line2.trim(),
+      city: formData.destinationAddress.city.trim(),
+      state: formData.destinationAddress.state.trim(),
+      pincode: formData.destinationAddress.pincode.trim(),
+      landmark: formData.destinationAddress.landmark.trim(),
+      contactNumber: formData.destinationAddress.contactNumber.trim()
     };
-  };
 
-  const charges = calculateCharges();
+    const payload = {
+      userId: state.user.id,
+      orderNumber: formData.orderNumber.trim(),
+      platform: formData.platform,
+      productDescription: formData.productDescription.trim(),
+      warehouseId: formData.warehouse?.id ?? null,
+      originalETA: formData.originalETA,
+      scheduledDeliveryDate: formData.scheduledDeliveryDate,
+      deliveryTimeSlot: formData.deliveryTimeSlot,
+      destinationAddress: normalisedAddress,
+      paymentDetails: {
+        baseHandlingFee: charges.baseHandlingFee,
+        storageFee: charges.storageFee,
+        deliveryCharge: charges.deliveryCharge,
+        gst: Number(charges.gst.toFixed(2)),
+        totalAmount: Number(charges.total.toFixed(2)),
+        paymentStatus: 'paid',
+        paymentMethod: selectedPaymentMethod
+      }
+    };
+
+    try {
+      const createdRequest = await apiClient.post('/requests', payload);
+
+      if (createdRequest?.id) {
+        navigate(`/request/${createdRequest.id}`);
+      } else {
+        navigate('/dashboard');
+      }
+    } catch (error) {
+      setSubmitError(error?.message || 'Unable to submit your request. Please try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+  const paymentOptions = [
+    { id: 'card', label: 'Credit/Debit Card' },
+    { id: 'upi', label: 'UPI' },
+    { id: 'netbanking', label: 'Net Banking' },
+    { id: 'wallet', label: 'Wallet' }
+  ];
 
   return (
     <div className="min-h-screen bg-gray-50 py-8">
@@ -430,7 +497,10 @@ const NewRequest = () => {
 
             <div className="flex justify-between mt-8">
               <button
-                onClick={() => setCurrentStep(1)}
+                onClick={() => {
+                  setSubmitError(null);
+                  setCurrentStep(1);
+                }}
                 className="px-6 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
               >
                 Previous
@@ -490,49 +560,56 @@ const NewRequest = () => {
               <div>
                 <h3 className="text-lg font-medium text-gray-900 mb-4">Payment Method</h3>
                 <div className="space-y-4">
-                  <div className="border border-gray-300 rounded-lg p-4">
-                    <label className="flex items-center">
-                      <input type="radio" name="payment" className="text-blue-600" defaultChecked />
-                      <span className="ml-2">Credit/Debit Card</span>
+                  {paymentOptions.map((option) => (
+                    <label
+                      key={option.id}
+                      className={`flex items-center border rounded-lg p-4 cursor-pointer transition-colors ${
+                        selectedPaymentMethod === option.id
+                          ? 'border-blue-500 bg-blue-50'
+                          : 'border-gray-300 hover:border-gray-400'
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name="payment"
+                        value={option.id}
+                        checked={selectedPaymentMethod === option.id}
+                        onChange={() => setSelectedPaymentMethod(option.id)}
+                        className="text-blue-600"
+                      />
+                      <span className="ml-2">{option.label}</span>
                     </label>
-                  </div>
-
-                  <div className="border border-gray-300 rounded-lg p-4">
-                    <label className="flex items-center">
-                      <input type="radio" name="payment" className="text-blue-600" />
-                      <span className="ml-2">UPI</span>
-                    </label>
-                  </div>
-
-                  <div className="border border-gray-300 rounded-lg p-4">
-                    <label className="flex items-center">
-                      <input type="radio" name="payment" className="text-blue-600" />
-                      <span className="ml-2">Net Banking</span>
-                    </label>
-                  </div>
-
-                  <div className="border border-gray-300 rounded-lg p-4">
-                    <label className="flex items-center">
-                      <input type="radio" name="payment" className="text-blue-600" />
-                      <span className="ml-2">Wallet</span>
-                    </label>
-                  </div>
+                  ))}
                 </div>
               </div>
             </div>
 
+            {submitError && (
+              <div className="mt-6 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">
+                {submitError}
+              </div>
+            )}
+
             <div className="flex justify-between mt-8">
               <button
-                onClick={() => setCurrentStep(2)}
+                onClick={() => {
+                  setSubmitError(null);
+                  setCurrentStep(2);
+                }}
                 className="px-6 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
               >
                 Previous
               </button>
               <button
                 onClick={handleSubmit}
-                className="px-8 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors"
+                disabled={isSubmitting}
+                className={`px-8 py-2 rounded-lg transition-colors ${
+                  isSubmitting
+                    ? 'bg-green-400 text-white cursor-not-allowed'
+                    : 'bg-green-600 text-white hover:bg-green-700'
+                }`}
               >
-                Proceed to Pay ₹{charges.total.toFixed(2)}
+                {isSubmitting ? 'Processing...' : `Proceed to Pay ₹${charges.total.toFixed(2)}`}
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- wire the new delivery request flow to submit form data to the API using the authenticated user
- capture payment method selection, normalise address details, and surface submission feedback in the UI
- store payment method metadata with delivery requests and guard payment updates from overwriting unset fields

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbe13ae0cc8321a4289bc938d3607e