### PR TITLE
Fix request tracking fallback and add interactive warehouse map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,14 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
+        "leaflet": "^1.9.4",
         "lucide-react": "^0.344.0",
         "mongodb": "^6.8.0",
         "mongodb-memory-server": "^10.1.4",
         "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-leaflet": "^4.2.1",
         "react-router-dom": "^7.9.3"
       },
       "devDependencies": {
@@ -1008,6 +1010,17 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@react-leaflet/core": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -4208,6 +4221,12 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -5310,6 +5329,20 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-leaflet": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-4.2.1.tgz",
+      "integrity": "sha512-p9chkvhcKrWn/H/1FFeVSqLdReGwn2qmiobOQGO3BifX+/vV/39qhY8dGqbdcPh1e6jxh/QHriLXr7a4eLFK4Q==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^2.1.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",

--- a/package.json
+++ b/package.json
@@ -16,13 +16,15 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "leaflet": "^1.9.4",
     "lucide-react": "^0.344.0",
+    "mongodb": "^6.8.0",
+    "mongodb-memory-server": "^10.1.4",
     "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^7.9.3",
-    "mongodb": "^6.8.0",
-    "mongodb-memory-server": "^10.1.4"
+    "react-leaflet": "^4.2.1",
+    "react-router-dom": "^7.9.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/src/components/Map/WarehouseMap.jsx
+++ b/src/components/Map/WarehouseMap.jsx
@@ -1,29 +1,92 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { MapPin, Navigation } from 'lucide-react';
-import { warehouses } from '../../data/mockData';
+import { MapContainer, Marker, Popup, TileLayer, useMap } from 'react-leaflet';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import marker2x from 'leaflet/dist/images/marker-icon-2x.png';
+import marker1x from 'leaflet/dist/images/marker-icon.png';
+import markerShadow from 'leaflet/dist/images/marker-shadow.png';
+
+import { warehouses as warehouseOptions } from '../../data/mockData';
+
+const defaultIcon = L.icon({
+  iconUrl: marker1x,
+  iconRetinaUrl: marker2x,
+  shadowUrl: markerShadow,
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+  shadowSize: [41, 41]
+});
+
+L.Marker.prototype.options.icon = defaultIcon;
+
+const DEFAULT_CENTER = [20.5937, 78.9629];
+
+const ChangeMapView = ({ center }) => {
+  const map = useMap();
+
+  useEffect(() => {
+    if (!center) {
+      return;
+    }
+
+    const nextCenter = Array.isArray(center) ? center : DEFAULT_CENTER;
+    map.flyTo(nextCenter, Math.max(map.getZoom(), 5), {
+      animate: true,
+      duration: 0.75
+    });
+  }, [center, map]);
+
+  return null;
+};
+
+ChangeMapView.propTypes = {
+  center: PropTypes.arrayOf(PropTypes.number)
+};
 
 const WarehouseMap = ({ onWarehouseSelect, selectedWarehouseId }) => {
   const [userLocation, setUserLocation] = useState('');
-  const [nearbyWarehouses, setNearbyWarehouses] = useState(warehouses);
+  const [nearbyWarehouses, setNearbyWarehouses] = useState(warehouseOptions);
+  const [isMapReady, setIsMapReady] = useState(false);
+
+  useEffect(() => {
+    setIsMapReady(true);
+  }, []);
 
   const handleLocationSearch = () => {
     const searchTerm = userLocation.toLowerCase();
 
-    if (searchTerm.includes('delhi')) {
-      setNearbyWarehouses(
-        warehouses.filter(w => w.address.includes('Delhi') || w.address.includes('Noida'))
-      );
-    } else if (searchTerm.includes('mumbai')) {
-      setNearbyWarehouses(
-        warehouses.filter(w => w.address.includes('Mumbai') || w.address.includes('Pune'))
-      );
-    } else if (searchTerm.includes('bangalore')) {
-      setNearbyWarehouses(warehouses.filter(w => w.address.includes('Bangalore')));
-    } else {
-      setNearbyWarehouses(warehouses);
+    if (!searchTerm) {
+      setNearbyWarehouses(warehouseOptions);
+      return;
     }
+
+    const filtered = warehouseOptions.filter((warehouse) => {
+      const haystack = `${warehouse.name} ${warehouse.address}`.toLowerCase();
+      return haystack.includes(searchTerm);
+    });
+
+    setNearbyWarehouses(filtered.length > 0 ? filtered : warehouseOptions);
   };
+
+  const selectedWarehouse = useMemo(
+    () => warehouseOptions.find((warehouse) => warehouse.id === selectedWarehouseId),
+    [selectedWarehouseId]
+  );
+
+  const mapCenter = useMemo(() => {
+    if (selectedWarehouse?.coordinates) {
+      return selectedWarehouse.coordinates;
+    }
+
+    if (nearbyWarehouses.length > 0 && nearbyWarehouses[0].coordinates) {
+      return nearbyWarehouses[0].coordinates;
+    }
+
+    return DEFAULT_CENTER;
+  }, [nearbyWarehouses, selectedWarehouse]);
 
   return (
     <div className="bg-white rounded-lg shadow-md p-6">
@@ -50,12 +113,45 @@ const WarehouseMap = ({ onWarehouseSelect, selectedWarehouseId }) => {
         </div>
       </div>
 
-      <div className="bg-gray-100 rounded-lg h-64 mb-6 flex items-center justify-center">
-        <div className="text-center text-gray-500">
-          <MapPin className="h-12 w-12 mx-auto mb-2" />
-          <p>Interactive Map View</p>
-          <p className="text-sm">(Map integration with Leaflet/Google Maps)</p>
-        </div>
+      <div className="bg-gray-100 rounded-lg h-64 mb-6 overflow-hidden">
+        {isMapReady ? (
+          <MapContainer
+            center={mapCenter}
+            zoom={5}
+            scrollWheelZoom
+            className="h-full w-full"
+          >
+            <ChangeMapView center={mapCenter} />
+            <TileLayer
+              attribution="&copy; <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors"
+              url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            />
+            {nearbyWarehouses.map((warehouse) => (
+              <Marker
+                key={warehouse.id}
+                position={warehouse.coordinates}
+                eventHandlers={{
+                  click: () => onWarehouseSelect?.(warehouse)
+                }}
+              >
+                <Popup>
+                  <div className="text-sm">
+                    <p className="font-semibold text-gray-900">{warehouse.name}</p>
+                    <p className="text-gray-600 mt-1">{warehouse.address}</p>
+                    <p className="text-gray-500 mt-1 text-xs">
+                      Capacity: {warehouse.capacity} · Hours: {warehouse.operatingHours}
+                    </p>
+                  </div>
+                </Popup>
+              </Marker>
+            ))}
+          </MapContainer>
+        ) : (
+          <div className="h-full flex items-center justify-center text-gray-500">
+            <MapPin className="h-12 w-12 mx-auto mb-2" />
+            <p>Loading map...</p>
+          </div>
+        )}
       </div>
 
       <div className="space-y-3">

--- a/src/pages/Request/RequestStatus.jsx
+++ b/src/pages/Request/RequestStatus.jsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Download, MessageCircle } from 'lucide-react';
 import StatusTracker from '../../components/StatusTracker/StatusTracker';
 
 import apiClient from '../../lib/api';
+import { mockRequests as mockRequestsData, warehouses as mockWarehouseData } from '../../data/mockData';
 
 const RequestStatus = () => {
   const { id } = useParams();
@@ -37,6 +38,19 @@ const RequestStatus = () => {
         }
       } catch (fetchError) {
         if (!isMounted) {
+          return;
+        }
+
+        const normalisedId = typeof id === 'string' ? id.toLowerCase() : '';
+        const fallbackRequest = mockRequestsData.find((item) => {
+          const orderNumber = item.orderNumber?.toLowerCase();
+          const requestId = item.id?.toLowerCase();
+          return requestId === normalisedId || orderNumber === normalisedId;
+        });
+
+        if (fallbackRequest) {
+          setRequest(fallbackRequest);
+          setWarehouses(mockWarehouseData);
           return;
         }
 


### PR DESCRIPTION
## Summary
- add Leaflet-powered interactive map for browsing and selecting warehouses
- fall back to mock request data when the API is unreachable so tracking and detail pages still resolve orders
- add the mapping dependencies required for the new interactive map experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc039fbf4c8321a414063074e6ff8a