### PR TITLE
Remove redundant warehouse list and align footer styling

### DIFF
--- a/src/components/Layout/Footer.jsx
+++ b/src/components/Layout/Footer.jsx
@@ -4,52 +4,54 @@ import { Link } from 'react-router-dom';
 
 const Footer = () => {
   return (
-    <footer id="site-footer" className="bg-gray-50 border-t border-gray-200">
+    <footer id="site-footer" className="bg-burrow-background border-t border-gray-200">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           <div className="col-span-1">
             <div className="flex items-center space-x-2 mb-4">
-              <Package className="h-8 w-8 text-blue-500" />
-              <span className="text-2xl font-bold text-gray-900">Burrow</span>
+              <Package className="h-8 w-8 text-burrow-primary" />
+              <span className="text-2xl font-extrabold bg-gradient-to-r from-burrow-primary to-burrow-secondary bg-clip-text text-transparent tracking-tight">
+                Burrow
+              </span>
             </div>
-            <p className="text-gray-600 text-sm">
+            <p className="text-burrow-text-secondary text-sm">
               Delivery rescheduling made simple. Take control of your deliveries and schedule them on your terms.
             </p>
           </div>
 
           <div>
-            <h3 className="font-semibold text-gray-900 mb-4">Services</h3>
-            <ul className="space-y-2 text-sm text-gray-600">
-              <li><Link to="/how-it-works" className="hover:text-blue-500 transition-colors">How It Works</Link></li>
-              <li><Link to="/warehouses" className="hover:text-blue-500 transition-colors">Warehouses</Link></li>
-              <li><Link to="/pricing" className="hover:text-blue-500 transition-colors">Pricing</Link></li>
-              <li><Link to="/tracking" className="hover:text-blue-500 transition-colors">Track Order</Link></li>
+            <h3 className="font-semibold text-burrow-text-primary mb-4">Services</h3>
+            <ul className="space-y-2 text-sm text-burrow-text-secondary">
+              <li><Link to="/how-it-works" className="hover:text-burrow-primary transition-colors">How It Works</Link></li>
+              <li><Link to="/warehouses" className="hover:text-burrow-primary transition-colors">Warehouses</Link></li>
+              <li><Link to="/pricing" className="hover:text-burrow-primary transition-colors">Pricing</Link></li>
+              <li><Link to="/tracking" className="hover:text-burrow-primary transition-colors">Track Order</Link></li>
             </ul>
           </div>
 
           <div>
-            <h3 className="font-semibold text-gray-900 mb-4">Support</h3>
-            <ul className="space-y-2 text-sm text-gray-600">
-              <li><Link to="/help" className="hover:text-blue-500 transition-colors">Help Center</Link></li>
-              <li><Link to="/contact" className="hover:text-blue-500 transition-colors">Contact Us</Link></li>
-              <li><Link to="/faq" className="hover:text-blue-500 transition-colors">FAQ</Link></li>
-              <li><Link to="/terms" className="hover:text-blue-500 transition-colors">Terms of Service</Link></li>
+            <h3 className="font-semibold text-burrow-text-primary mb-4">Support</h3>
+            <ul className="space-y-2 text-sm text-burrow-text-secondary">
+              <li><Link to="/help" className="hover:text-burrow-primary transition-colors">Help Center</Link></li>
+              <li><Link to="/contact" className="hover:text-burrow-primary transition-colors">Contact Us</Link></li>
+              <li><Link to="/faq" className="hover:text-burrow-primary transition-colors">FAQ</Link></li>
+              <li><Link to="/terms" className="hover:text-burrow-primary transition-colors">Terms of Service</Link></li>
             </ul>
           </div>
 
           <div>
-            <h3 className="font-semibold text-gray-900 mb-4">Contact</h3>
-            <div className="space-y-2 text-sm text-gray-600">
+            <h3 className="font-semibold text-burrow-text-primary mb-4">Contact</h3>
+            <div className="space-y-2 text-sm text-burrow-text-secondary">
               <div className="flex items-center space-x-2">
-                <Mail className="h-4 w-4" />
+                <Mail className="h-4 w-4 text-burrow-primary" />
                 <span>support@burrow.com</span>
               </div>
               <div className="flex items-center space-x-2">
-                <Phone className="h-4 w-4" />
+                <Phone className="h-4 w-4 text-burrow-primary" />
                 <span>+91 98765 43210</span>
               </div>
               <div className="flex items-center space-x-2">
-                <MapPin className="h-4 w-4" />
+                <MapPin className="h-4 w-4 text-burrow-primary" />
                 <span>Mumbai, India</span>
               </div>
             </div>
@@ -57,9 +59,9 @@ const Footer = () => {
         </div>
 
         <div className="border-t border-gray-200 mt-8 pt-8 text-center">
-          <p className="text-sm text-gray-600">
+          <p className="text-sm text-burrow-text-secondary">
             © 2024 Burrow. All rights reserved. |
-            <Link to="/privacy" className="hover:text-blue-500 transition-colors ml-1">Privacy Policy</Link>
+            <Link to="/privacy" className="hover:text-burrow-primary transition-colors ml-1">Privacy Policy</Link>
           </p>
         </div>
       </div>

--- a/src/components/Map/WarehouseMap.jsx
+++ b/src/components/Map/WarehouseMap.jsx
@@ -154,35 +154,6 @@ const WarehouseMap = ({ onWarehouseSelect, selectedWarehouseId }) => {
         )}
       </div>
 
-      <div className="space-y-3">
-        <h4 className="font-medium text-burrow-text-primary">Nearby Warehouses</h4>
-
-        {nearbyWarehouses.map((warehouse) => (
-          <div
-            key={warehouse.id}
-            className={`p-4 border-2 rounded-lg cursor-pointer transition-all shadow-sm ${
-              selectedWarehouseId === warehouse.id
-                ? 'border-burrow-primary bg-burrow-primary/10 shadow-md'
-                : 'border-gray-200 hover:border-burrow-primary/40 hover:shadow-md'
-            }`}
-            onClick={() => onWarehouseSelect?.(warehouse)}
-          >
-            <div className="flex items-start justify-between">
-              <div className="flex-1">
-                <h5 className="font-medium text-burrow-text-primary">{warehouse.name}</h5>
-                <p className="text-sm text-burrow-text-secondary mt-1">{warehouse.address}</p>
-                <div className="flex items-center gap-4 mt-2 text-xs text-gray-500">
-                  <span>Capacity: {warehouse.capacity}</span>
-                  <span>Hours: {warehouse.operatingHours}</span>
-                </div>
-              </div>
-              <div className="flex items-center text-burrow-primary">
-                <MapPin className="h-4 w-4" />
-              </div>
-            </div>
-          </div>
-        ))}
-      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- remove the redundant "Nearby Warehouses" list beneath the map component
- restyle the footer to match the header palette and typography for a consistent brand look

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e358d9f3288321b35f7c77787a694e