### PR TITLE
Remove map search UI and relocate warehouse summary

### DIFF
--- a/src/components/Layout/Footer.jsx
+++ b/src/components/Layout/Footer.jsx
@@ -4,52 +4,54 @@ import { Link } from 'react-router-dom';
 
 const Footer = () => {
   return (
-    <footer id="site-footer" className="bg-gray-50 border-t border-gray-200">
+    <footer id="site-footer" className="bg-burrow-background border-t border-gray-200">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           <div className="col-span-1">
             <div className="flex items-center space-x-2 mb-4">
-              <Package className="h-8 w-8 text-blue-500" />
-              <span className="text-2xl font-bold text-gray-900">Burrow</span>
+              <Package className="h-8 w-8 text-burrow-primary" />
+              <span className="text-2xl font-extrabold bg-gradient-to-r from-burrow-primary to-burrow-secondary bg-clip-text text-transparent tracking-tight">
+                Burrow
+              </span>
             </div>
-            <p className="text-gray-600 text-sm">
+            <p className="text-burrow-text-secondary text-sm">
               Delivery rescheduling made simple. Take control of your deliveries and schedule them on your terms.
             </p>
           </div>
 
           <div>
-            <h3 className="font-semibold text-gray-900 mb-4">Services</h3>
-            <ul className="space-y-2 text-sm text-gray-600">
-              <li><Link to="/how-it-works" className="hover:text-blue-500 transition-colors">How It Works</Link></li>
-              <li><Link to="/warehouses" className="hover:text-blue-500 transition-colors">Warehouses</Link></li>
-              <li><Link to="/pricing" className="hover:text-blue-500 transition-colors">Pricing</Link></li>
-              <li><Link to="/tracking" className="hover:text-blue-500 transition-colors">Track Order</Link></li>
+            <h3 className="font-semibold text-burrow-text-primary mb-4">Services</h3>
+            <ul className="space-y-2 text-sm text-burrow-text-secondary">
+              <li><Link to="/how-it-works" className="hover:text-burrow-primary transition-colors">How It Works</Link></li>
+              <li><Link to="/warehouses" className="hover:text-burrow-primary transition-colors">Warehouses</Link></li>
+              <li><Link to="/pricing" className="hover:text-burrow-primary transition-colors">Pricing</Link></li>
+              <li><Link to="/tracking" className="hover:text-burrow-primary transition-colors">Track Order</Link></li>
             </ul>
           </div>
 
           <div>
-            <h3 className="font-semibold text-gray-900 mb-4">Support</h3>
-            <ul className="space-y-2 text-sm text-gray-600">
-              <li><Link to="/help" className="hover:text-blue-500 transition-colors">Help Center</Link></li>
-              <li><Link to="/contact" className="hover:text-blue-500 transition-colors">Contact Us</Link></li>
-              <li><Link to="/faq" className="hover:text-blue-500 transition-colors">FAQ</Link></li>
-              <li><Link to="/terms" className="hover:text-blue-500 transition-colors">Terms of Service</Link></li>
+            <h3 className="font-semibold text-burrow-text-primary mb-4">Support</h3>
+            <ul className="space-y-2 text-sm text-burrow-text-secondary">
+              <li><Link to="/help" className="hover:text-burrow-primary transition-colors">Help Center</Link></li>
+              <li><Link to="/contact" className="hover:text-burrow-primary transition-colors">Contact Us</Link></li>
+              <li><Link to="/faq" className="hover:text-burrow-primary transition-colors">FAQ</Link></li>
+              <li><Link to="/terms" className="hover:text-burrow-primary transition-colors">Terms of Service</Link></li>
             </ul>
           </div>
 
           <div>
-            <h3 className="font-semibold text-gray-900 mb-4">Contact</h3>
-            <div className="space-y-2 text-sm text-gray-600">
+            <h3 className="font-semibold text-burrow-text-primary mb-4">Contact</h3>
+            <div className="space-y-2 text-sm text-burrow-text-secondary">
               <div className="flex items-center space-x-2">
-                <Mail className="h-4 w-4" />
+                <Mail className="h-4 w-4 text-burrow-primary" />
                 <span>support@burrow.com</span>
               </div>
               <div className="flex items-center space-x-2">
-                <Phone className="h-4 w-4" />
+                <Phone className="h-4 w-4 text-burrow-primary" />
                 <span>+91 98765 43210</span>
               </div>
               <div className="flex items-center space-x-2">
-                <MapPin className="h-4 w-4" />
+                <MapPin className="h-4 w-4 text-burrow-primary" />
                 <span>Mumbai, India</span>
               </div>
             </div>
@@ -57,9 +59,9 @@ const Footer = () => {
         </div>
 
         <div className="border-t border-gray-200 mt-8 pt-8 text-center">
-          <p className="text-sm text-gray-600">
+          <p className="text-sm text-burrow-text-secondary">
             © 2024 Burrow. All rights reserved. |
-            <Link to="/privacy" className="hover:text-blue-500 transition-colors ml-1">Privacy Policy</Link>
+            <Link to="/privacy" className="hover:text-burrow-primary transition-colors ml-1">Privacy Policy</Link>
           </p>
         </div>
       </div>

--- a/src/components/Map/WarehouseMap.jsx
+++ b/src/components/Map/WarehouseMap.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
-import { MapPin, Navigation } from 'lucide-react';
+import { CheckCircle, MapPin } from 'lucide-react';
 import { MapContainer, Marker, Popup, TileLayer, useMap } from 'react-leaflet';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
@@ -47,29 +47,11 @@ ChangeMapView.propTypes = {
 };
 
 const WarehouseMap = ({ onWarehouseSelect, selectedWarehouseId }) => {
-  const [userLocation, setUserLocation] = useState('');
-  const [nearbyWarehouses, setNearbyWarehouses] = useState(warehouseOptions);
   const [isMapReady, setIsMapReady] = useState(false);
 
   useEffect(() => {
     setIsMapReady(true);
   }, []);
-
-  const handleLocationSearch = () => {
-    const searchTerm = userLocation.toLowerCase();
-
-    if (!searchTerm) {
-      setNearbyWarehouses(warehouseOptions);
-      return;
-    }
-
-    const filtered = warehouseOptions.filter((warehouse) => {
-      const haystack = `${warehouse.name} ${warehouse.address}`.toLowerCase();
-      return haystack.includes(searchTerm);
-    });
-
-    setNearbyWarehouses(filtered.length > 0 ? filtered : warehouseOptions);
-  };
 
   const selectedWarehouse = useMemo(
     () => warehouseOptions.find((warehouse) => warehouse.id === selectedWarehouseId),
@@ -81,37 +63,16 @@ const WarehouseMap = ({ onWarehouseSelect, selectedWarehouseId }) => {
       return selectedWarehouse.coordinates;
     }
 
-    if (nearbyWarehouses.length > 0 && nearbyWarehouses[0].coordinates) {
-      return nearbyWarehouses[0].coordinates;
+    if (warehouseOptions.length > 0 && warehouseOptions[0].coordinates) {
+      return warehouseOptions[0].coordinates;
     }
 
     return DEFAULT_CENTER;
-  }, [nearbyWarehouses, selectedWarehouse]);
+  }, [selectedWarehouse]);
 
   return (
     <div className="bg-white rounded-lg shadow-md p-6">
-      <div className="mb-6">
-        <h3 className="text-xl font-semibold text-burrow-text-primary mb-4">Find Nearby Warehouses</h3>
-
-        <div className="flex gap-3">
-          <div className="flex-1">
-            <input
-              type="text"
-              placeholder="Enter your location (city, pincode, area)"
-              value={userLocation}
-              onChange={(e) => setUserLocation(e.target.value)}
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-burrow-primary focus:border-transparent transition-shadow"
-            />
-          </div>
-          <button
-            onClick={handleLocationSearch}
-            className="px-6 py-2 bg-burrow-primary text-white rounded-lg hover:bg-burrow-accent transition-colors flex items-center gap-2 shadow-sm"
-          >
-            <Navigation className="h-4 w-4" />
-            Search
-          </button>
-        </div>
-      </div>
+      <h3 className="text-xl font-semibold text-burrow-text-primary mb-4">Find Nearby Warehouses</h3>
 
       <div className="bg-burrow-background rounded-lg h-64 mb-6 overflow-hidden">
         {isMapReady ? (
@@ -126,7 +87,7 @@ const WarehouseMap = ({ onWarehouseSelect, selectedWarehouseId }) => {
               attribution="&copy; <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors"
               url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
             />
-            {nearbyWarehouses.map((warehouse) => (
+            {warehouseOptions.map((warehouse) => (
               <Marker
                 key={warehouse.id}
                 position={warehouse.coordinates}
@@ -154,35 +115,21 @@ const WarehouseMap = ({ onWarehouseSelect, selectedWarehouseId }) => {
         )}
       </div>
 
-      <div className="space-y-3">
-        <h4 className="font-medium text-burrow-text-primary">Nearby Warehouses</h4>
-
-        {nearbyWarehouses.map((warehouse) => (
-          <div
-            key={warehouse.id}
-            className={`p-4 border-2 rounded-lg cursor-pointer transition-all shadow-sm ${
-              selectedWarehouseId === warehouse.id
-                ? 'border-burrow-primary bg-burrow-primary/10 shadow-md'
-                : 'border-gray-200 hover:border-burrow-primary/40 hover:shadow-md'
-            }`}
-            onClick={() => onWarehouseSelect?.(warehouse)}
-          >
-            <div className="flex items-start justify-between">
-              <div className="flex-1">
-                <h5 className="font-medium text-burrow-text-primary">{warehouse.name}</h5>
-                <p className="text-sm text-burrow-text-secondary mt-1">{warehouse.address}</p>
-                <div className="flex items-center gap-4 mt-2 text-xs text-gray-500">
-                  <span>Capacity: {warehouse.capacity}</span>
-                  <span>Hours: {warehouse.operatingHours}</span>
-                </div>
-              </div>
-              <div className="flex items-center text-burrow-primary">
-                <MapPin className="h-4 w-4" />
-              </div>
+      <div className="bg-burrow-background rounded-lg border border-burrow-primary/30 p-4 min-h-[112px] flex flex-col justify-center">
+        {selectedWarehouse ? (
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <CheckCircle className="h-5 w-5 text-green-500" />
+              <span className="font-medium text-burrow-text-primary">Warehouse Selected</span>
             </div>
+            <p className="text-burrow-text-primary font-semibold">{selectedWarehouse.name}</p>
+            <p className="text-burrow-text-secondary text-sm">{selectedWarehouse.address}</p>
           </div>
-        ))}
+        ) : (
+          <p className="text-burrow-text-secondary text-sm text-center">Select a warehouse to view its details here.</p>
+        )}
       </div>
+
     </div>
   );
 };
@@ -191,5 +138,5 @@ export default WarehouseMap;
 
 WarehouseMap.propTypes = {
   onWarehouseSelect: PropTypes.func,
-  selectedWarehouseId: PropTypes.string,
+  selectedWarehouseId: PropTypes.string
 };

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Clock, Shield, MapPin, Calendar, ArrowRight, CheckCircle } from 'lucide-react';
+import { Clock, Shield, MapPin, Calendar, ArrowRight } from 'lucide-react';
 import WarehouseMap from '../components/Map/WarehouseMap';
 import { warehouses } from '../data/mockData';
 
@@ -143,17 +143,6 @@ const Home = () => {
                   </div>
                 </div>
               ))}
-
-              {selectedWarehouse && (
-                <div className="bg-green-50 border border-green-200 rounded-lg p-4 mt-4">
-                  <div className="flex items-center space-x-2">
-                    <CheckCircle className="h-5 w-5 text-green-500" />
-                    <span className="font-medium text-green-800">Warehouse Selected</span>
-                  </div>
-                  <p className="text-green-700 mt-1">{selectedWarehouse.name}</p>
-                  <p className="text-green-600 text-sm">{selectedWarehouse.address}</p>
-                </div>
-              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- remove the unused map search input/button and rely on the default warehouse list
- display the selected warehouse details in a dedicated panel beneath the map and keep the sidebar cards unchanged

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e358d9f3288321b35f7c77787a694e