### PR TITLE
Add pre-provisioned operator accounts

### DIFF
--- a/server/lib/seedDemoData.js
+++ b/server/lib/seedDemoData.js
@@ -16,7 +16,20 @@ export const DEMO_USERS = [
     password: 'AdminDemo1',
     role: 'operator',
     privileges: ['operator']
-
+  },
+  {
+    name: 'Logistics Operator One',
+    email: 'operator.one@burrow.com',
+    password: 'OperatorDemo1',
+    role: 'operator',
+    privileges: ['operator']
+  },
+  {
+    name: 'Logistics Operator Two',
+    email: 'operator.two@burrow.com',
+    password: 'OperatorDemo2',
+    role: 'operator',
+    privileges: ['operator']
   }
 ];
 

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -26,6 +26,28 @@ const DEMO_ACCOUNTS = {
       privileges: ['operator'],
       isActive: true
     }
+  },
+  'operator.one@burrow.com': {
+    password: 'OperatorDemo1',
+    user: {
+      id: 'demo-operator-one',
+      name: 'Logistics Operator One',
+      email: 'operator.one@burrow.com',
+      role: 'operator',
+      privileges: ['operator'],
+      isActive: true
+    }
+  },
+  'operator.two@burrow.com': {
+    password: 'OperatorDemo2',
+    user: {
+      id: 'demo-operator-two',
+      name: 'Logistics Operator Two',
+      email: 'operator.two@burrow.com',
+      role: 'operator',
+      privileges: ['operator'],
+      isActive: true
+    }
   }
 };
 

--- a/src/pages/Auth/Login.jsx
+++ b/src/pages/Auth/Login.jsx
@@ -50,6 +50,8 @@ const Login = () => {
           <p className="text-blue-800 text-sm font-medium mb-2">Demo Credentials:</p>
           <p className="text-blue-700 text-xs">Customer: user@test.com / UserDemo1</p>
           <p className="text-blue-700 text-xs">Admin: admin@burrow.com / AdminDemo1</p>
+          <p className="text-blue-700 text-xs">Operator 1: operator.one@burrow.com / OperatorDemo1</p>
+          <p className="text-blue-700 text-xs">Operator 2: operator.two@burrow.com / OperatorDemo2</p>
         </div>
 
         <form className="mt-8 space-y-6" onSubmit={handleSubmit}>


### PR DESCRIPTION
## Summary
- seed two additional operator demo users so their credentials are provisioned in Mongo
- mirror the operator demo accounts in the authentication fallback for instant access
- surface the new operator credentials on the login page for quick reference

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e36b8839ac8321ae7b6bbb1312fff0