### PR TITLE
Fix delivery request updates returning false 404 responses

### DIFF
--- a/server/routes/deliveryRequests.js
+++ b/server/routes/deliveryRequests.js
@@ -268,7 +268,10 @@ router.put('/:id/reschedule', async (req, res) => {
     { returnDocument: 'after' }
   );
 
-  const updatedRequest = updateResult.value;
+  const updatedRequest =
+    updateResult && typeof updateResult === 'object' && 'value' in updateResult
+      ? updateResult.value
+      : updateResult;
 
   if (!updatedRequest) {
     return res.status(404).json({ message: 'Request not found' });
@@ -311,7 +314,10 @@ router.patch('/:id/status', async (req, res) => {
     { returnDocument: 'after' }
   );
 
-  const updatedRequest = updateResult.value;
+  const updatedRequest =
+    updateResult && typeof updateResult === 'object' && 'value' in updateResult
+      ? updateResult.value
+      : updateResult;
 
   if (!updatedRequest) {
     return res.status(404).json({ message: 'Request not found' });
@@ -376,7 +382,10 @@ router.patch('/:id/payment', async (req, res) => {
     { returnDocument: 'after' }
   );
 
-  const updatedRequest = updateResult.value;
+  const updatedRequest =
+    updateResult && typeof updateResult === 'object' && 'value' in updateResult
+      ? updateResult.value
+      : updateResult;
 
   if (!updatedRequest) {
     return res.status(404).json({ message: 'Request not found' });


### PR DESCRIPTION
## Summary
- ensure delivery request update routes handle both ModifyResult and document responses from MongoDB
- prevent successful status, reschedule, and payment updates from being treated as missing requests

## Testing
- curl -i -X PATCH http://localhost:4000/requests/68e39a2b3dab47fe114a74ec/status -H 'Content-Type: application/json' -d '{"status":"approved"}'

------
https://chatgpt.com/codex/tasks/task_e_68e398456364832185e0e8d8db0df7f5