### PR TITLE
Fix request update endpoints returning false 404 errors

### DIFF
--- a/server/routes/deliveryRequests.js
+++ b/server/routes/deliveryRequests.js
@@ -283,10 +283,7 @@ router.put('/:id/reschedule', async (req, res) => {
     { returnDocument: 'after' }
   );
 
-  const updatedRequest =
-    updateResult && typeof updateResult === 'object' && 'value' in updateResult
-      ? updateResult.value
-      : updateResult;
+  const updatedRequest = await resolveUpdatedRequest(collection, idQuery, updateResult);
 
   if (!updatedRequest) {
     return res.status(404).json({ message: 'Request not found' });
@@ -330,10 +327,7 @@ router.patch('/:id/status', async (req, res) => {
     { returnDocument: 'after' }
   );
 
-  const updatedRequest =
-    updateResult && typeof updateResult === 'object' && 'value' in updateResult
-      ? updateResult.value
-      : updateResult;
+  const updatedRequest = await resolveUpdatedRequest(collection, idQuery, updateResult);
 
   if (!updatedRequest) {
     return res.status(404).json({ message: 'Request not found' });
@@ -400,10 +394,7 @@ router.patch('/:id/payment', async (req, res) => {
     { returnDocument: 'after' }
   );
 
-  const updatedRequest =
-    updateResult && typeof updateResult === 'object' && 'value' in updateResult
-      ? updateResult.value
-      : updateResult;
+  const updatedRequest = await resolveUpdatedRequest(collection, idQuery, updateResult);
 
   if (!updatedRequest) {
     return res.status(404).json({ message: 'Request not found' });


### PR DESCRIPTION
## Summary
- ensure delivery request update endpoints resolve the updated document before returning
- prevent erroneous 404 responses when MongoDB reports an update without including the value

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e39ccddecc832196f5ff3a09105276