### PR TITLE
Ensure delivery request updates return the refreshed record

### DIFF
--- a/server/routes/deliveryRequests.js
+++ b/server/routes/deliveryRequests.js
@@ -68,6 +68,26 @@ function buildRequestIdQuery(rawId) {
   return { _id: rawId };
 }
 
+async function resolveUpdatedRequest(collection, idQuery, updateResult) {
+  if (updateResult && typeof updateResult === 'object') {
+    if ('value' in updateResult && updateResult.value) {
+      return updateResult.value;
+    }
+
+    const lastErrorObject = updateResult.lastErrorObject;
+
+    if (lastErrorObject?.n > 0 || lastErrorObject?.updatedExisting) {
+      return collection.findOne(idQuery);
+    }
+  }
+
+  if (!updateResult) {
+    return null;
+  }
+
+  return collection.findOne(idQuery);
+}
+
 router.get('/', async (req, res) => {
   const db = ensureDatabase(req, res);
   if (!db) {
@@ -253,8 +273,9 @@ router.put('/:id/reschedule', async (req, res) => {
   }
 
   const now = new Date();
+  const collection = db.collection('deliveryRequests');
 
-  const updateResult = await db.collection('deliveryRequests').findOneAndUpdate(
+  const updateResult = await collection.findOneAndUpdate(
     idQuery,
     {
       $set: {
@@ -268,7 +289,7 @@ router.put('/:id/reschedule', async (req, res) => {
     { returnDocument: 'after' }
   );
 
-  const updatedRequest = updateResult.value;
+  const updatedRequest = await resolveUpdatedRequest(collection, idQuery, updateResult);
 
   if (!updatedRequest) {
     return res.status(404).json({ message: 'Request not found' });
@@ -301,8 +322,9 @@ router.patch('/:id/status', async (req, res) => {
   }
 
   const now = new Date();
+  const collection = db.collection('deliveryRequests');
 
-  const updateResult = await db.collection('deliveryRequests').findOneAndUpdate(
+  const updateResult = await collection.findOneAndUpdate(
     idQuery,
     {
       $set: { status, updatedAt: now },
@@ -311,7 +333,7 @@ router.patch('/:id/status', async (req, res) => {
     { returnDocument: 'after' }
   );
 
-  const updatedRequest = updateResult.value;
+  const updatedRequest = await resolveUpdatedRequest(collection, idQuery, updateResult);
 
   if (!updatedRequest) {
     return res.status(404).json({ message: 'Request not found' });
@@ -370,13 +392,15 @@ router.patch('/:id/payment', async (req, res) => {
     updateSet['paymentDetails.paymentMethod'] = paymentDetails.paymentMethod;
   }
 
-  const updateResult = await db.collection('deliveryRequests').findOneAndUpdate(
+  const collection = db.collection('deliveryRequests');
+
+  const updateResult = await collection.findOneAndUpdate(
     idQuery,
     { $set: updateSet },
     { returnDocument: 'after' }
   );
 
-  const updatedRequest = updateResult.value;
+  const updatedRequest = await resolveUpdatedRequest(collection, idQuery, updateResult);
 
   if (!updatedRequest) {
     return res.status(404).json({ message: 'Request not found' });


### PR DESCRIPTION
## Summary
- expand the resolveUpdatedRequest helper to treat acknowledged updates reported via lastErrorObject.n as success
- always refetch the delivery request when MongoDB omits the updated document so PATCH endpoints can respond with the latest data

## Testing
- curl -i -s -X PATCH http://localhost:4000/requests/68e39f6b69c74262b9a6f730/status -H 'Content-Type: application/json' -d '{"status":"approved"}'

------
https://chatgpt.com/codex/tasks/task_e_68e398456364832185e0e8d8db0df7f5