### PR TITLE
Reload page after modal status updates

### DIFF
--- a/src/pages/Operator/OperatorDashboard.jsx
+++ b/src/pages/Operator/OperatorDashboard.jsx
@@ -95,13 +95,24 @@ const OperatorDashboard = () => {
       });
 
       setUpdateError(null);
-      if (typeof window !== 'undefined') {
-        window.location.reload();
+      setRequests((previousRequests) =>
+        previousRequests.map((request) =>
+          request.id === updatedRequest?.id ? { ...request, ...updatedRequest } : request
+        )
+      );
+
+      if (selectedRequest?.id === updatedRequest?.id) {
+        setSelectedRequest((current) => ({ ...current, ...updatedRequest }));
       }
 
       return updatedRequest;
     } catch (updateError_) {
-      setUpdateError(updateError_?.message || 'Unable to update request status.');
+      const errorMessage =
+        updateError_?.status === 404
+          ? 'Request not found'
+          : updateError_?.message || 'Unable to update request status.';
+
+      setUpdateError(errorMessage);
       throw updateError_;
     } finally {
       setUpdatingRequestId(null);
@@ -120,8 +131,12 @@ const OperatorDashboard = () => {
     const previousStatus = selectedRequest.status;
 
     try {
-      await handleStatusUpdate(selectedRequest.id, modalStatus, modalNotes);
+      const updatedRequest = await handleStatusUpdate(selectedRequest.id, modalStatus, modalNotes);
       setModalNotes('');
+
+      if (updatedRequest && typeof window !== 'undefined') {
+        window.location.reload();
+      }
     } catch {
       setModalStatus(previousStatus);
     }


### PR DESCRIPTION
## Summary
- only reload the operator dashboard when a modal status update succeeds
- update local request state instead of forcing a reload on every status change
- display a clear "Request not found" message when a status update fails

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3a532117883218cb2370ee685f50a