### PR TITLE
Adjust map layout height to match content

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -117,7 +117,7 @@ const Home = () => {
           </div>
 
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-start">
-            <div className="h-full rounded-lg shadow-md overflow-hidden">
+            <div className="h-fit rounded-lg shadow-md overflow-hidden">
               <WarehouseMap
                 onWarehouseSelect={setSelectedWarehouse}
                 selectedWarehouseId={selectedWarehouse?.id}


### PR DESCRIPTION
## Summary
- update the map container on the home page to use height that fits its content so it no longer extends past the warehouse details card

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3ad2550f88321b438c0da94f8affd