### PR TITLE
Add subtle page fade animations

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,57 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@keyframes burrow-fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.page-fade {
+  animation: burrow-fade-in-up 0.5s ease-out both;
+}
+
+.fade-stagger > * {
+  opacity: 0;
+  transform: translateY(12px);
+  animation: burrow-fade-in-up 0.6s ease-out both;
+}
+
+.fade-stagger > *:nth-child(1) {
+  animation-delay: 0.05s;
+}
+
+.fade-stagger > *:nth-child(2) {
+  animation-delay: 0.1s;
+}
+
+.fade-stagger > *:nth-child(3) {
+  animation-delay: 0.15s;
+}
+
+.fade-stagger > *:nth-child(4) {
+  animation-delay: 0.2s;
+}
+
+.fade-stagger > *:nth-child(5) {
+  animation-delay: 0.25s;
+}
+
+.fade-stagger > *:nth-child(6) {
+  animation-delay: 0.3s;
+}
+
+.fade-stagger > *:nth-child(7) {
+  animation-delay: 0.35s;
+}
+
+.fade-stagger > *:nth-child(8) {
+  animation-delay: 0.4s;
+}

--- a/src/pages/Auth/Login.jsx
+++ b/src/pages/Auth/Login.jsx
@@ -33,7 +33,7 @@ const Login = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 page-fade">
       <div className="max-w-md w-full space-y-8">
         <div className="text-center">
           <h2 className="text-3xl font-bold text-gray-900">Welcome back</h2>
@@ -46,7 +46,7 @@ const Login = () => {
           </div>
         )}
 
-        <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+        <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 page-fade">
           <p className="text-blue-800 text-sm font-medium mb-2">Demo Credentials:</p>
           <p className="text-blue-700 text-xs">Customer: user@test.com / UserDemo1</p>
           <p className="text-blue-700 text-xs">Admin: admin@burrow.com / AdminDemo1</p>
@@ -54,8 +54,8 @@ const Login = () => {
           <p className="text-blue-700 text-xs">Operator 2: operator.two@burrow.com / OperatorDemo2</p>
         </div>
 
-        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
-          <div className="space-y-4">
+        <form className="mt-8 space-y-6 fade-stagger" onSubmit={handleSubmit}>
+          <div className="space-y-4 fade-stagger">
             <div>
               <label htmlFor="email" className="sr-only">Email address</label>
               <div className="relative">

--- a/src/pages/Auth/Register.jsx
+++ b/src/pages/Auth/Register.jsx
@@ -86,7 +86,7 @@ const Register = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 page-fade">
       <div className="max-w-md w-full space-y-8">
         <div className="text-center">
           <h2 className="text-3xl font-bold text-gray-900">Create your account</h2>
@@ -99,8 +99,8 @@ const Register = () => {
           </div>
         )}
 
-        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
-          <div className="space-y-4">
+        <form className="mt-8 space-y-6 fade-stagger" onSubmit={handleSubmit}>
+          <div className="space-y-4 fade-stagger">
             <div>
               <label htmlFor="name" className="sr-only">Full Name</label>
               <div className="relative">

--- a/src/pages/Dashboard/ConsumerDashboard.jsx
+++ b/src/pages/Dashboard/ConsumerDashboard.jsx
@@ -120,14 +120,14 @@ const ConsumerDashboard = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 py-8">
+    <div className="min-h-screen bg-gray-50 py-8 page-fade">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="mb-8">
+        <div className="mb-8 page-fade">
           <h1 className="text-3xl font-bold text-gray-900">Welcome back, {state.user?.name}!</h1>
           <p className="text-gray-600 mt-1">Manage your deliveries and schedule new requests</p>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8 fade-stagger">
           <div className="bg-white rounded-lg shadow-md p-6">
             <div className="flex items-center">
               <div className="flex-shrink-0 w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center">
@@ -165,7 +165,7 @@ const ConsumerDashboard = () => {
           </div>
         </div>
 
-        <div className="bg-white rounded-lg shadow-md p-6 mb-8">
+        <div className="bg-white rounded-lg shadow-md p-6 mb-8 page-fade">
           <h2 className="text-xl font-semibold text-gray-900 mb-4">Quick Actions</h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <Link
@@ -186,7 +186,7 @@ const ConsumerDashboard = () => {
           </div>
         </div>
 
-        <div className="bg-white rounded-lg shadow-md">
+        <div className="bg-white rounded-lg shadow-md page-fade">
           <div className="px-6 py-4 border-b border-gray-200">
             <h2 className="text-xl font-semibold text-gray-900">Recent Requests</h2>
           </div>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -57,7 +57,7 @@ const Home = () => {
   ];
 
   return (
-    <div className="min-h-screen bg-burrow-background">
+    <div className="min-h-screen bg-burrow-background page-fade">
       <section className="bg-gradient-to-br from-burrow-background to-burrow-primary/10 py-24">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center">
@@ -87,7 +87,7 @@ const Home = () => {
             </p>
           </div>
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-8 mb-16">
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-8 mb-16 fade-stagger">
             {benefits.map((benefit, idx) => (
               <div
                 key={idx}
@@ -124,7 +124,7 @@ const Home = () => {
               />
             </div>
 
-            <div className="flex flex-col space-y-4 max-h-[650px] overflow-y-auto">
+            <div className="flex flex-col space-y-4 max-h-[650px] overflow-y-auto fade-stagger">
               {warehouses.map((warehouse) => (
                 <div
                   key={warehouse.id}
@@ -155,7 +155,7 @@ const Home = () => {
             <p className="text-lg text-burrow-text-secondary">Three simple steps to take control of your deliveries</p>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-8 fade-stagger">
             {howItWorks.map((step, index) => (
               <div key={index} className="text-center">
                 <div className="w-20 h-20 bg-burrow-primary text-white rounded-full flex items-center justify-center text-2xl font-bold mx-auto mb-4">

--- a/src/pages/Operator/OperatorDashboard.jsx
+++ b/src/pages/Operator/OperatorDashboard.jsx
@@ -154,8 +154,8 @@ const OperatorDashboard = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <div className="bg-white shadow-sm border-b border-gray-200">
+    <div className="min-h-screen bg-gray-50 page-fade">
+      <div className="bg-white shadow-sm border-b border-gray-200 page-fade">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
             <h1 className="text-2xl font-bold text-gray-900">Operator Dashboard</h1>
@@ -167,7 +167,7 @@ const OperatorDashboard = () => {
       </div>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8 fade-stagger">
           <div className="bg-white rounded-lg shadow-md p-6">
             <div className="flex items-center">
               <div className="flex-shrink-0 w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center">
@@ -217,7 +217,7 @@ const OperatorDashboard = () => {
           </div>
         </div>
 
-        <div className="bg-white rounded-lg shadow-md p-6 mb-8">
+        <div className="bg-white rounded-lg shadow-md p-6 mb-8 page-fade">
           <div className="flex flex-col sm:flex-row gap-4">
             <div className="flex-1">
               <div className="relative">

--- a/src/pages/Request/NewRequest.jsx
+++ b/src/pages/Request/NewRequest.jsx
@@ -218,10 +218,10 @@ const NewRequest = () => {
   ];
 
   return (
-    <div className="min-h-screen bg-gray-50 py-8">
+    <div className="min-h-screen bg-gray-50 py-8 page-fade">
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="mb-8">
-          <div className="flex items-center justify-between">
+        <div className="mb-8 page-fade">
+          <div className="flex items-center justify-between fade-stagger">
             {[1, 2, 3].map((step) => (
               <div key={step} className="flex items-center">
                 <div
@@ -247,14 +247,14 @@ const NewRequest = () => {
         </div>
 
         {currentStep === 1 && (
-          <div className="bg-white rounded-lg shadow-md p-6">
+          <div className="bg-white rounded-lg shadow-md p-6 page-fade">
             <div className="flex items-center mb-6">
               <Upload className="h-6 w-6 text-blue-500 mr-2" />
               <h2 className="text-2xl font-bold text-gray-900">Order Details</h2>
             </div>
 
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-              <div className="space-y-6">
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 fade-stagger">
+              <div className="space-y-6 fade-stagger">
                 {/* Order number */}
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-2">
@@ -350,7 +350,7 @@ const NewRequest = () => {
               </div>
 
               {/* Map */}
-              <div>
+              <div className="page-fade">
                 <h3 className="text-lg font-medium text-gray-900 mb-4">Select Warehouse</h3>
                 <WarehouseMap
                   onWarehouseSelect={(warehouse) => setFormData((prev) => ({ ...prev, warehouse }))}
@@ -372,15 +372,15 @@ const NewRequest = () => {
         )}
 
         {currentStep === 2 && (
-          <div className="bg-white rounded-lg shadow-md p-6">
+          <div className="bg-white rounded-lg shadow-md p-6 page-fade">
             <div className="flex items-center mb-6">
               <Calendar className="h-6 w-6 text-blue-500 mr-2" />
               <h2 className="text-2xl font-bold text-gray-900">Schedule Delivery</h2>
             </div>
 
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 fade-stagger">
               {/* Left */}
-              <div className="space-y-6">
+              <div className="space-y-6 fade-stagger">
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-2">
                     Preferred Delivery Date *
@@ -426,7 +426,7 @@ const NewRequest = () => {
               </div>
 
               {/* Right */}
-              <div className="space-y-6">
+              <div className="space-y-6 fade-stagger">
                 <h3 className="text-lg font-medium text-gray-900">Destination Address</h3>
 
                 <div className="grid grid-cols-1 gap-4">
@@ -537,104 +537,102 @@ const NewRequest = () => {
         )}
 
         {currentStep === 3 && (
-  <div className="bg-white rounded-lg shadow-md p-6">
-    <div className="flex items-center mb-6">
-      <CreditCard className="h-6 w-6 text-blue-500 mr-2" />
-      <h2 className="text-2xl font-bold text-gray-900">Payment Details</h2>
-    </div>
-
-    <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-      <div>
-        <h3 className="text-lg font-medium text-gray-900 mb-4">Service Charges</h3>
-        <div className="bg-gray-50 rounded-lg p-4 space-y-3">
-          <div className="flex justify-between">
-            <span className="text-gray-600">Base Handling Fee</span>
-            <span className="font-medium">₹{charges.baseHandlingFee}</span>
-          </div>
-          <div className="flex justify-between">
-            <span className="text-gray-600">Storage Fee (2 extra days)</span>
-            <span className="font-medium">₹{charges.storageFee}</span>
-          </div>
-          <div className="flex justify-between">
-            <span className="text-gray-600">Delivery Charge</span>
-            <span className="font-medium">₹{charges.deliveryCharge}</span>
-          </div>
-          <div className="border-t pt-3">
-            <div className="flex justify-between">
-              <span className="text-gray-600">Subtotal</span>
-              <span className="font-medium">₹{charges.subtotal}</span>
+          <div className="bg-white rounded-lg shadow-md p-6 page-fade">
+            <div className="flex items-center mb-6">
+              <CreditCard className="h-6 w-6 text-blue-500 mr-2" />
+              <h2 className="text-2xl font-bold text-gray-900">Payment Details</h2>
             </div>
-            <div className="flex justify-between">
-              <span className="text-gray-600">GST (18%)</span>
-              <span className="font-medium">₹{charges.gst.toFixed(2)}</span>
+
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 fade-stagger">
+              <div className="page-fade">
+                <h3 className="text-lg font-medium text-gray-900 mb-4">Service Charges</h3>
+                <div className="bg-gray-50 rounded-lg p-4 space-y-3 fade-stagger">
+                  <div className="flex justify-between">
+                    <span className="text-gray-600">Base Handling Fee</span>
+                    <span className="font-medium">₹{charges.baseHandlingFee}</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-gray-600">Storage Fee (2 extra days)</span>
+                    <span className="font-medium">₹{charges.storageFee}</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-gray-600">Delivery Charge</span>
+                    <span className="font-medium">₹{charges.deliveryCharge}</span>
+                  </div>
+                  <div className="border-t pt-3">
+                    <div className="flex justify-between">
+                      <span className="text-gray-600">Subtotal</span>
+                      <span className="font-medium">₹{charges.subtotal}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-gray-600">GST (18%)</span>
+                      <span className="font-medium">₹{charges.gst.toFixed(2)}</span>
+                    </div>
+                  </div>
+                  <div className="border-t pt-3">
+                    <div className="flex justify-between text-lg font-bold">
+                      <span>Total Amount</span>
+                      <span className="text-blue-600">₹{charges.total.toFixed(2)}</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="space-y-4 fade-stagger">
+                <h3 className="text-lg font-medium text-gray-900 mb-4">Payment Method</h3>
+                {paymentOptions.map((option) => (
+                  <label
+                    key={option.id}
+                    className={`flex items-center border rounded-lg p-4 cursor-pointer transition-colors ${
+                      selectedPaymentMethod === option.id
+                        ? 'border-blue-500 bg-blue-50'
+                        : 'border-gray-300 hover:border-gray-400'
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      name="payment"
+                      value={option.id}
+                      checked={selectedPaymentMethod === option.id}
+                      onChange={() => setSelectedPaymentMethod(option.id)}
+                      className="text-blue-600"
+                    />
+                    <span className="ml-2">{option.label}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            {submitError && (
+              <div className="mt-6 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600 page-fade">
+                {submitError}
+              </div>
+            )}
+
+            <div className="flex justify-between mt-8">
+              <button
+                onClick={() => {
+                  setSubmitError(null);
+                  setCurrentStep(2);
+                }}
+                className="px-6 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
+              >
+                Previous
+              </button>
+              <button
+                onClick={handleSubmit}
+                disabled={isSubmitting}
+                className={`px-8 py-2 rounded-lg transition-colors ${
+                  isSubmitting
+                    ? 'bg-green-400 text-white cursor-not-allowed'
+                    : 'bg-green-600 text-white hover:bg-green-700'
+                }`}
+              >
+                {isSubmitting ? 'Processing...' : `Proceed to Pay ₹${charges.total.toFixed(2)}`}
+              </button>
             </div>
           </div>
-          <div className="border-t pt-3">
-            <div className="flex justify-between text-lg font-bold">
-              <span>Total Amount</span>
-              <span className="text-blue-600">₹{charges.total.toFixed(2)}</span>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div>
-        <h3 className="text-lg font-medium text-gray-900 mb-4">Payment Method</h3>
-        <div className="space-y-4">
-          {paymentOptions.map((option) => (
-            <label
-              key={option.id}
-              className={`flex items-center border rounded-lg p-4 cursor-pointer transition-colors ${
-                selectedPaymentMethod === option.id
-                  ? 'border-blue-500 bg-blue-50'
-                  : 'border-gray-300 hover:border-gray-400'
-              }`}
-            >
-              <input
-                type="radio"
-                name="payment"
-                value={option.id}
-                checked={selectedPaymentMethod === option.id}
-                onChange={() => setSelectedPaymentMethod(option.id)}
-                className="text-blue-600"
-              />
-              <span className="ml-2">{option.label}</span>
-            </label>
-          ))}
-        </div>
-      </div>
-    </div>
-
-    {submitError && (
-      <div className="mt-6 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">
-        {submitError}
-      </div>
-    )}
-
-    <div className="flex justify-between mt-8">
-      <button
-        onClick={() => {
-          setSubmitError(null);
-          setCurrentStep(2);
-        }}
-        className="px-6 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
-      >
-        Previous
-      </button>
-      <button
-        onClick={handleSubmit}
-        disabled={isSubmitting}
-        className={`px-8 py-2 rounded-lg transition-colors ${
-          isSubmitting
-            ? 'bg-green-400 text-white cursor-not-allowed'
-            : 'bg-green-600 text-white hover:bg-green-700'
-        }`}
-      >
-        {isSubmitting ? 'Processing...' : `Proceed to Pay ₹${charges.total.toFixed(2)}`}
-      </button>
-    </div>
-  </div>
-)}
+        )}
 
 </div>  
 </div>   

--- a/src/pages/Request/RequestStatus.jsx
+++ b/src/pages/Request/RequestStatus.jsx
@@ -80,7 +80,7 @@ const RequestStatus = () => {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center page-fade">
         <p className="text-gray-600">Loading request details...</p>
       </div>
     );
@@ -88,7 +88,7 @@ const RequestStatus = () => {
 
   if (notFound) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center page-fade">
         <div className="text-center">
           <h2 className="text-2xl font-bold text-gray-900">Request not found</h2>
           <p className="text-gray-600 mt-2">The request you&apos;re looking for doesn&apos;t exist.</p>
@@ -102,7 +102,7 @@ const RequestStatus = () => {
 
   if (error) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center page-fade">
         <div className="text-center">
           <h2 className="text-2xl font-bold text-gray-900">Something went wrong</h2>
           <p className="text-gray-600 mt-2">{error}</p>
@@ -121,9 +121,9 @@ const RequestStatus = () => {
   const paymentStatus = request.paymentDetails?.paymentStatus ?? 'pending';
 
   return (
-    <div className="min-h-screen bg-gray-50 py-8">
+    <div className="min-h-screen bg-gray-50 py-8 page-fade">
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="mb-8">
+        <div className="mb-8 page-fade">
           <div className="flex items-center space-x-4 mb-4">
             <Link to="/dashboard" className="flex items-center text-gray-600 hover:text-gray-800 transition-colors">
               <ArrowLeft className="h-5 w-5 mr-1" />
@@ -195,13 +195,13 @@ const RequestStatus = () => {
           </div>
         </div>
 
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-          <div className="lg:col-span-2">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 fade-stagger">
+          <div className="lg:col-span-2 page-fade">
             <StatusTracker currentStatus={request.status} statusHistory={request.statusHistory ?? []} />
           </div>
 
           <div className="space-y-6">
-            <div className="bg-white rounded-lg shadow-md p-6">
+            <div className="bg-white rounded-lg shadow-md p-6 page-fade">
               <h3 className="text-lg font-semibold text-gray-900 mb-4">Order Information</h3>
 
               <div className="space-y-3 text-sm">
@@ -229,7 +229,7 @@ const RequestStatus = () => {
               </div>
             </div>
 
-            <div className="bg-white rounded-lg shadow-md p-6">
+            <div className="bg-white rounded-lg shadow-md p-6 page-fade">
               <h3 className="text-lg font-semibold text-gray-900 mb-4">Delivery Details</h3>
 
               <div className="space-y-3 text-sm">
@@ -270,7 +270,7 @@ const RequestStatus = () => {
             </div>
 
             {warehouse && (
-              <div className="bg-white rounded-lg shadow-md p-6">
+              <div className="bg-white rounded-lg shadow-md p-6 page-fade">
                 <h3 className="text-lg font-semibold text-gray-900 mb-4">Warehouse Details</h3>
 
                 <div className="space-y-3 text-sm">
@@ -292,7 +292,7 @@ const RequestStatus = () => {
               </div>
             )}
 
-            <div className="bg-white rounded-lg shadow-md p-6">
+            <div className="bg-white rounded-lg shadow-md p-6 page-fade">
               <h3 className="text-lg font-semibold text-gray-900 mb-4">Payment Details</h3>
 
               <div className="space-y-2 text-sm">

--- a/src/pages/Request/TrackRequest.jsx
+++ b/src/pages/Request/TrackRequest.jsx
@@ -152,15 +152,15 @@ const TrackRequest = () => {
   };
 
   return (
-    <div className="bg-gray-50 min-h-full py-12">
+    <div className="bg-gray-50 min-h-full py-12 page-fade">
       <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="bg-white shadow-md rounded-lg p-8">
+        <div className="bg-white shadow-md rounded-lg p-8 page-fade">
           <h1 className="text-2xl font-bold text-gray-900 mb-2">Track your delivery request</h1>
           <p className="text-sm text-gray-600 mb-6">
             Enter your order number to view the current status, scheduled date, and destination details of your request.
           </p>
 
-          <form onSubmit={handleSubmit} className="space-y-4">
+          <form onSubmit={handleSubmit} className="space-y-4 fade-stagger">
             <div>
               <label htmlFor="orderNumber" className="block text-sm font-medium text-gray-700">
                 Order number
@@ -198,7 +198,7 @@ const TrackRequest = () => {
           )}
 
           {hasSearched && !error && (
-            <div className="mt-8 space-y-4">
+            <div className="mt-8 space-y-4 fade-stagger">
               {results.length > 0 ? (
                 results.map((request) => renderResult(request))
               ) : (


### PR DESCRIPTION
## Summary
- add shared fade-in and stagger animation utilities for page content
- apply subtle entrance animations across home, auth, dashboard, and request workflow screens
- animate request status fallback views for loading and error consistency

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3cce4712c8321a8ac02bf7a8429be