### PR TITLE
Add missing operator status filter options and request validations

### DIFF
--- a/src/pages/Operator/OperatorDashboard.jsx
+++ b/src/pages/Operator/OperatorDashboard.jsx
@@ -254,8 +254,11 @@ const OperatorDashboard = () => {
                   <option value="submitted">Submitted</option>
                   <option value="approval_pending">Pending Approval</option>
                   <option value="approved">Approved</option>
+                  <option value="rejected">Rejected</option>
+                  <option value="parcel_expected">Parcel Expected</option>
                   <option value="parcel_arrived">Parcel Arrived</option>
                   <option value="in_storage">In Storage</option>
+                  <option value="preparing_dispatch">Preparing Dispatch</option>
                   <option value="out_for_delivery">Out for Delivery</option>
                   <option value="delivered">Delivered</option>
                 </select>


### PR DESCRIPTION
## Summary
- add the missing Rejected, Parcel Expected, and Preparing Dispatch options to the operator dashboard status filter so all updatable statuses can be queried
- add contextual validations to the schedule delivery and payment steps so required fields must be completed before submission

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3d18e8fb88321a43d8fa40a84f25c