### PR TITLE
Revamp Burrow theme to match new mock

### DIFF
--- a/src/components/Layout/Footer.jsx
+++ b/src/components/Layout/Footer.jsx
@@ -4,23 +4,25 @@ import { Link } from 'react-router-dom';
 
 const Footer = () => {
   return (
-    <footer id="site-footer" className="bg-burrow-background border-t border-gray-200">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
+    <footer id="site-footer" className="bg-burrow-background/70 border-t border-burrow-border">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-12">
           <div className="col-span-1">
-            <div className="flex items-center space-x-2 mb-4">
-              <Package className="h-8 w-8 text-burrow-primary" />
-              <span className="text-2xl font-extrabold bg-gradient-to-r from-burrow-primary to-burrow-secondary bg-clip-text text-transparent tracking-tight">
+            <div className="flex items-center space-x-3 mb-4">
+              <div className="h-10 w-10 rounded-2xl bg-burrow-primary/10 flex items-center justify-center">
+                <Package className="h-6 w-6 text-burrow-primary" />
+              </div>
+              <span className="text-2xl font-extrabold bg-gradient-to-r from-burrow-primary via-burrow-secondary to-burrow-accent bg-clip-text text-transparent tracking-tight">
                 Burrow
               </span>
             </div>
-            <p className="text-burrow-text-secondary text-sm">
+            <p className="text-burrow-text-secondary text-sm leading-relaxed">
               Delivery rescheduling made simple. Take control of your deliveries and schedule them on your terms.
             </p>
           </div>
 
           <div>
-            <h3 className="font-semibold text-burrow-text-primary mb-4">Services</h3>
+            <h3 className="font-semibold text-burrow-text-primary mb-4 uppercase tracking-wide text-xs">Services</h3>
             <ul className="space-y-2 text-sm text-burrow-text-secondary">
               <li><Link to="/how-it-works" className="hover:text-burrow-primary transition-colors">How It Works</Link></li>
               <li><Link to="/warehouses" className="hover:text-burrow-primary transition-colors">Warehouses</Link></li>
@@ -30,7 +32,7 @@ const Footer = () => {
           </div>
 
           <div>
-            <h3 className="font-semibold text-burrow-text-primary mb-4">Support</h3>
+            <h3 className="font-semibold text-burrow-text-primary mb-4 uppercase tracking-wide text-xs">Support</h3>
             <ul className="space-y-2 text-sm text-burrow-text-secondary">
               <li><Link to="/help" className="hover:text-burrow-primary transition-colors">Help Center</Link></li>
               <li><Link to="/contact" className="hover:text-burrow-primary transition-colors">Contact Us</Link></li>
@@ -40,7 +42,7 @@ const Footer = () => {
           </div>
 
           <div>
-            <h3 className="font-semibold text-burrow-text-primary mb-4">Contact</h3>
+            <h3 className="font-semibold text-burrow-text-primary mb-4 uppercase tracking-wide text-xs">Contact</h3>
             <div className="space-y-2 text-sm text-burrow-text-secondary">
               <div className="flex items-center space-x-2">
                 <Mail className="h-4 w-4 text-burrow-primary" />
@@ -58,7 +60,7 @@ const Footer = () => {
           </div>
         </div>
 
-        <div className="border-t border-gray-200 mt-8 pt-8 text-center">
+        <div className="border-t border-burrow-border mt-12 pt-8 text-center">
           <p className="text-sm text-burrow-text-secondary">
             © 2024 Burrow. All rights reserved. |
             <Link to="/privacy" className="hover:text-burrow-primary transition-colors ml-1">Privacy Policy</Link>

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -16,19 +16,21 @@ const Header = () => {
   const isOperatorRoute = location.pathname.startsWith('/operator');
 
   return (
-    <header className="sticky top-0 z-50 bg-burrow-background shadow-sm border-b border-gray-200">
+    <header className="sticky top-0 z-50 backdrop-blur bg-burrow-background/95 border-b border-burrow-border">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex justify-between items-center h-16">
+        <div className="flex justify-between items-center h-20">
           <div className="flex items-center">
             <Link to="/" className="flex items-center space-x-2">
-              <Package className="h-8 w-8 text-burrow-primary" />
-              <span className="text-2xl font-extrabold bg-gradient-to-r from-burrow-primary to-burrow-secondary bg-clip-text text-transparent tracking-tight">
+              <div className="h-10 w-10 rounded-2xl bg-burrow-primary/10 flex items-center justify-center">
+                <Package className="h-6 w-6 text-burrow-primary" />
+              </div>
+              <span className="text-2xl font-extrabold bg-gradient-to-r from-burrow-primary via-burrow-secondary to-burrow-accent bg-clip-text text-transparent tracking-tight">
                 Burrow
               </span>
             </Link>
           </div>
 
-          <nav className="flex items-center space-x-8">
+          <nav className="flex items-center space-x-6">
             {!state.user ? (
               <>
                 <Link
@@ -39,7 +41,7 @@ const Header = () => {
                 </Link>
                 <Link
                   to="/register"
-                  className="bg-burrow-primary text-white px-4 py-2 rounded-lg hover:bg-burrow-accent transition-colors"
+                  className="burrow-button-primary"
                 >
                   Sign Up
                 </Link>
@@ -66,7 +68,7 @@ const Header = () => {
                 {state.user.role === 'operator' && !isOperatorRoute && (
                   <Link
                     to="/operator/dashboard"
-                    className="text-burrow-primary hover:text-indigo-700 transition-colors font-medium"
+                    className="text-burrow-primary hover:text-burrow-secondary transition-colors font-medium"
                   >
                     Operator Portal
                   </Link>
@@ -80,7 +82,7 @@ const Header = () => {
 
                   <button
                     onClick={handleLogout}
-                    className="flex items-center space-x-1 text-burrow-text-secondary hover:text-red-500 transition-colors"
+                    className="flex items-center space-x-1 text-burrow-text-secondary hover:text-burrow-secondary transition-colors"
                   >
                     <LogOut className="h-4 w-4" />
                     <span className="text-sm">Logout</span>

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,118 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  :root {
+    color-scheme: light;
+  }
+
+  body {
+    @apply bg-burrow-background text-burrow-text-primary antialiased;
+    background-image: radial-gradient(circle at 10% 20%, rgba(240, 184, 96, 0.2) 0, transparent 45%),
+      radial-gradient(circle at 90% 10%, rgba(58, 91, 160, 0.18) 0, transparent 55%),
+      linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(247, 245, 248, 1));
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    @apply text-burrow-text-primary;
+  }
+
+  ::selection {
+    background: rgba(240, 184, 96, 0.35);
+    color: #2D2A32;
+  }
+
+  .text-gray-900,
+  .text-gray-800 {
+    @apply text-burrow-text-primary;
+  }
+
+  .text-gray-700,
+  .text-gray-600,
+  .text-gray-500 {
+    @apply text-burrow-text-secondary;
+  }
+
+  .text-gray-400 {
+    color: rgba(95, 91, 98, 0.55);
+  }
+
+  .text-blue-600,
+  .text-blue-500,
+  .text-blue-700,
+  .text-blue-800 {
+    @apply text-burrow-primary;
+  }
+
+  .hover\:text-blue-500:hover,
+  .hover\:text-blue-600:hover,
+  .hover\:text-blue-700:hover {
+    @apply text-burrow-secondary;
+  }
+
+  .bg-gray-50 {
+    @apply bg-burrow-background/80;
+  }
+
+  .bg-gray-100,
+  .bg-gray-200 {
+    @apply bg-burrow-muted;
+  }
+
+  .border-gray-100,
+  .border-gray-200,
+  .border-gray-300 {
+    @apply border-burrow-border;
+  }
+
+  .bg-blue-600,
+  .bg-blue-700 {
+    @apply bg-burrow-primary;
+  }
+
+  .hover\:bg-blue-700:hover,
+  .hover\:bg-blue-600:hover {
+    @apply bg-burrow-secondary;
+  }
+
+  .bg-blue-50 {
+    background-color: rgba(58, 91, 160, 0.08);
+  }
+
+  .border-blue-200 {
+    border-color: rgba(58, 91, 160, 0.2);
+  }
+
+  .focus\:ring-blue-500,
+  .focus\:ring-blue-500:focus,
+  .focus\:ring-blue-500:focus-visible,
+  .focus\:ring-blue-500:focus-within {
+    --tw-ring-color: theme('colors.burrow.primary');
+  }
+
+  .hover\:bg-gray-50:hover {
+    background-color: rgba(255, 255, 255, 0.8);
+  }
+}
+
+@layer components {
+  .burrow-card {
+    @apply bg-burrow-surface border border-burrow-border rounded-3xl shadow-burrow-soft;
+  }
+
+  .burrow-chip {
+    @apply inline-flex items-center rounded-full px-4 py-1.5 text-sm font-medium bg-burrow-muted text-burrow-text-secondary;
+  }
+
+  .burrow-button-primary {
+    @apply inline-flex items-center justify-center gap-2 rounded-full bg-burrow-primary px-8 py-3 text-base font-semibold text-white transition-all duration-200 hover:-translate-y-0.5 hover:shadow-burrow;
+  }
+
+  .burrow-button-ghost {
+    @apply inline-flex items-center justify-center gap-2 rounded-full border border-burrow-border bg-transparent px-8 py-3 text-base font-semibold text-burrow-text-primary transition-colors duration-200 hover:bg-white/70;
+  }
+}
+
 @keyframes burrow-fade-in-up {
   from {
     opacity: 0;

--- a/src/pages/Auth/Login.jsx
+++ b/src/pages/Auth/Login.jsx
@@ -33,115 +33,110 @@ const Login = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 page-fade">
+    <div className="min-h-screen flex items-center justify-center py-16 px-4 sm:px-6 lg:px-8 page-fade">
       <div className="max-w-md w-full space-y-8">
-        <div className="text-center">
-          <h2 className="text-3xl font-bold text-gray-900">Welcome back</h2>
-          <p className="mt-2 text-gray-600">Sign in to your Burrow account</p>
+        <div className="text-center space-y-2">
+          <span className="burrow-chip">Welcome back</span>
+          <h2 className="text-3xl font-bold">Sign in to your Burrow account</h2>
+          <p className="text-burrow-text-secondary">We&apos;re glad to keep your deliveries on track.</p>
         </div>
 
         {state.error && (
-          <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+          <div className="burrow-card border-red-200/70 bg-red-50/60 p-4 text-left">
             <p className="text-red-600 text-sm">{state.error}</p>
           </div>
         )}
 
-        <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-          <p className="text-blue-800 text-sm font-medium mb-2">Demo Credentials For An Operator View:</p>
+        <div className="burrow-card p-5 bg-burrow-muted/60">
+          <p className="text-burrow-primary text-sm font-semibold mb-2">Demo credentials for an operator view:</p>
 
-          <p className="text-blue-700 text-xs">Operator 1: operator.one@burrow.com / OperatorDemo1</p>
-          <p className="text-blue-700 text-xs">Operator 2: operator.two@burrow.com / OperatorDemo2</p>
+          <p className="text-burrow-text-secondary text-xs">Operator 1: operator.one@burrow.com / OperatorDemo1</p>
+          <p className="text-burrow-text-secondary text-xs">Operator 2: operator.two@burrow.com / OperatorDemo2</p>
         </div>
 
         <form className="mt-8 space-y-6 fade-stagger" onSubmit={handleSubmit}>
-          <div className="space-y-4 fade-stagger">
-            <div>
-              <label htmlFor="email" className="sr-only">Email address</label>
-              <div className="relative">
-                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                  <Mail className="h-5 w-5 text-gray-400" />
+          <div className="burrow-card p-8 space-y-6">
+            <div className="space-y-4 fade-stagger">
+              <div>
+                <label htmlFor="email" className="sr-only">Email address</label>
+                <div className="relative">
+                  <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                    <Mail className="h-5 w-5 text-burrow-text-secondary" />
+                  </div>
+                  <input
+                    id="email"
+                    name="email"
+                    type="email"
+                    required
+                    value={formData.email}
+                    onChange={handleChange}
+                    className="pl-10 w-full px-3 py-3 border border-burrow-border rounded-2xl focus:ring-2 focus:ring-burrow-primary focus:border-transparent bg-white/90"
+                    placeholder="Email address"
+                  />
                 </div>
-                <input
-                  id="email"
-                  name="email"
-                  type="email"
-                  required
-                  value={formData.email}
-                  onChange={handleChange}
-                  className="pl-10 w-full px-3 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                  placeholder="Email address"
-                />
+              </div>
+
+              <div>
+                <label htmlFor="password" className="sr-only">Password</label>
+                <div className="relative">
+                  <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                    <Lock className="h-5 w-5 text-burrow-text-secondary" />
+                  </div>
+                  <input
+                    id="password"
+                    name="password"
+                    type={showPassword ? 'text' : 'password'}
+                    required
+                    value={formData.password}
+                    onChange={handleChange}
+                    className="pl-10 pr-10 w-full px-3 py-3 border border-burrow-border rounded-2xl focus:ring-2 focus:ring-burrow-primary focus:border-transparent bg-white/90"
+                    placeholder="Password"
+                  />
+                  <button
+                    type="button"
+                    className="absolute inset-y-0 right-0 pr-3 flex items-center text-burrow-text-secondary"
+                    onClick={() => setShowPassword(!showPassword)}
+                  >
+                    {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+                  </button>
+                </div>
               </div>
             </div>
 
-            <div>
-              <label htmlFor="password" className="sr-only">Password</label>
-              <div className="relative">
-                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                  <Lock className="h-5 w-5 text-gray-400" />
-                </div>
+            <div className="flex items-center justify-between">
+              <label className="flex items-center gap-2 text-sm text-burrow-text-secondary">
                 <input
-                  id="password"
-                  name="password"
-                  type={showPassword ? 'text' : 'password'}
-                  required
-                  value={formData.password}
-                  onChange={handleChange}
-                  className="pl-10 pr-10 w-full px-3 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                  placeholder="Password"
+                  id="remember-me"
+                  name="remember-me"
+                  type="checkbox"
+                  checked={rememberMe}
+                  onChange={(event) => setRememberMe(event.target.checked)}
+                  className="h-4 w-4 rounded border-burrow-border text-burrow-primary focus:ring-burrow-primary"
                 />
-                <button
-                  type="button"
-                  className="absolute inset-y-0 right-0 pr-3 flex items-center"
-                  onClick={() => setShowPassword(!showPassword)}
-                >
-                  {showPassword ? (
-                    <EyeOff className="h-5 w-5 text-gray-400" />
-                  ) : (
-                    <Eye className="h-5 w-5 text-gray-400" />
-                  )}
-                </button>
-              </div>
-            </div>
-          </div>
-
-          <div className="flex items-center justify-between">
-            <div className="flex items-center">
-              <input
-                id="remember-me"
-                name="remember-me"
-                type="checkbox"
-                checked={rememberMe}
-                onChange={(event) => setRememberMe(event.target.checked)}
-                className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-              />
-              <label htmlFor="remember-me" className="ml-2 block text-sm text-gray-700">
                 Remember me
               </label>
+
+              <div className="text-sm">
+                <Link to="/forgot-password" className="text-burrow-primary hover:text-burrow-secondary">
+                  Forgot password?
+                </Link>
+              </div>
             </div>
 
-            <div className="text-sm">
-              <Link to="/forgot-password" className="text-blue-600 hover:text-blue-500">
-                Forgot password?
-              </Link>
-            </div>
+            <button
+              type="submit"
+              disabled={state.isLoading}
+              className="burrow-button-primary w-full justify-center disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {state.isLoading ? 'Signing in...' : 'Sign in'}
+            </button>
           </div>
 
-          <button
-            type="submit"
-            disabled={state.isLoading}
-            className="w-full flex justify-center py-3 px-4 border border-transparent rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {state.isLoading ? 'Signing in...' : 'Sign in'}
-          </button>
-
-          <div className="text-center">
-            <p className="text-sm text-gray-600">
-              Don&apos;t have an account?{' '}
-              <Link to="/register" className="text-blue-600 hover:text-blue-500 font-medium">
-                Sign up
-              </Link>
-            </p>
+          <div className="text-center text-sm text-burrow-text-secondary">
+            Don&apos;t have an account?{' '}
+            <Link to="/register" className="text-burrow-primary hover:text-burrow-secondary font-medium">
+              Sign up
+            </Link>
           </div>
         </form>
       </div>

--- a/src/pages/Auth/Register.jsx
+++ b/src/pages/Auth/Register.jsx
@@ -86,26 +86,27 @@ const Register = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 page-fade">
+    <div className="min-h-screen flex items-center justify-center py-16 px-4 sm:px-6 lg:px-8 page-fade">
       <div className="max-w-md w-full space-y-8">
-        <div className="text-center">
-          <h2 className="text-3xl font-bold text-gray-900">Create your account</h2>
-          <p className="mt-2 text-gray-600">Join Burrow and take control of your deliveries</p>
+        <div className="text-center space-y-2">
+          <span className="burrow-chip">Join Burrow</span>
+          <h2 className="text-3xl font-bold">Create your account</h2>
+          <p className="text-burrow-text-secondary">Take control of your deliveries in minutes.</p>
         </div>
 
         {state.error && (
-          <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+          <div className="burrow-card border-red-200/70 bg-red-50/60 p-4 text-left">
             <p className="text-red-600 text-sm">{state.error}</p>
           </div>
         )}
 
         <form className="mt-8 space-y-6 fade-stagger" onSubmit={handleSubmit}>
-          <div className="space-y-4 fade-stagger">
+          <div className="burrow-card p-8 space-y-5 fade-stagger">
             <div>
               <label htmlFor="name" className="sr-only">Full Name</label>
               <div className="relative">
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                  <User className="h-5 w-5 text-gray-400" />
+                  <User className="h-5 w-5 text-burrow-text-secondary" />
                 </div>
                 <input
                   id="name"
@@ -114,8 +115,8 @@ const Register = () => {
                   required
                   value={formData.name}
                   onChange={handleChange}
-                  className={`pl-10 w-full px-3 py-3 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent ${
-                    errors.name ? 'border-red-300' : 'border-gray-300'
+                  className={`pl-10 w-full px-3 py-3 border rounded-2xl focus:ring-2 focus:ring-burrow-primary focus:border-transparent bg-white/90 ${
+                    errors.name ? 'border-red-300' : 'border-burrow-border'
                   }`}
                   placeholder="Full Name"
                 />
@@ -127,7 +128,7 @@ const Register = () => {
               <label htmlFor="email" className="sr-only">Email address</label>
               <div className="relative">
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                  <Mail className="h-5 w-5 text-gray-400" />
+                  <Mail className="h-5 w-5 text-burrow-text-secondary" />
                 </div>
                 <input
                   id="email"
@@ -136,8 +137,8 @@ const Register = () => {
                   required
                   value={formData.email}
                   onChange={handleChange}
-                  className={`pl-10 w-full px-3 py-3 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent ${
-                    errors.email ? 'border-red-300' : 'border-gray-300'
+                  className={`pl-10 w-full px-3 py-3 border rounded-2xl focus:ring-2 focus:ring-burrow-primary focus:border-transparent bg-white/90 ${
+                    errors.email ? 'border-red-300' : 'border-burrow-border'
                   }`}
                   placeholder="Email address"
                 />
@@ -149,7 +150,7 @@ const Register = () => {
               <label htmlFor="phone" className="sr-only">Phone Number</label>
               <div className="relative">
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                  <Phone className="h-5 w-5 text-gray-400" />
+                  <Phone className="h-5 w-5 text-burrow-text-secondary" />
                 </div>
                 <input
                   id="phone"
@@ -158,8 +159,8 @@ const Register = () => {
                   required
                   value={formData.phone}
                   onChange={handleChange}
-                  className={`pl-10 w-full px-3 py-3 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent ${
-                    errors.phone ? 'border-red-300' : 'border-gray-300'
+                  className={`pl-10 w-full px-3 py-3 border rounded-2xl focus:ring-2 focus:ring-burrow-primary focus:border-transparent bg-white/90 ${
+                    errors.phone ? 'border-red-300' : 'border-burrow-border'
                   }`}
                   placeholder="Phone Number"
                 />
@@ -171,7 +172,7 @@ const Register = () => {
               <label htmlFor="password" className="sr-only">Password</label>
               <div className="relative">
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                  <Lock className="h-5 w-5 text-gray-400" />
+                  <Lock className="h-5 w-5 text-burrow-text-secondary" />
                 </div>
                 <input
                   id="password"
@@ -180,21 +181,17 @@ const Register = () => {
                   required
                   value={formData.password}
                   onChange={handleChange}
-                  className={`pl-10 pr-10 w-full px-3 py-3 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent ${
-                    errors.password ? 'border-red-300' : 'border-gray-300'
+                  className={`pl-10 pr-10 w-full px-3 py-3 border rounded-2xl focus:ring-2 focus:ring-burrow-primary focus:border-transparent bg-white/90 ${
+                    errors.password ? 'border-red-300' : 'border-burrow-border'
                   }`}
                   placeholder="Password"
                 />
                 <button
                   type="button"
-                  className="absolute inset-y-0 right-0 pr-3 flex items-center"
+                  className="absolute inset-y-0 right-0 pr-3 flex items-center text-burrow-text-secondary"
                   onClick={() => setShowPassword(!showPassword)}
                 >
-                  {showPassword ? (
-                    <EyeOff className="h-5 w-5 text-gray-400" />
-                  ) : (
-                    <Eye className="h-5 w-5 text-gray-400" />
-                  )}
+                  {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
                 </button>
               </div>
               {errors.password && <p className="text-red-600 text-xs mt-1">{errors.password}</p>}
@@ -204,7 +201,7 @@ const Register = () => {
               <label htmlFor="confirmPassword" className="sr-only">Confirm Password</label>
               <div className="relative">
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                  <Lock className="h-5 w-5 text-gray-400" />
+                  <Lock className="h-5 w-5 text-burrow-text-secondary" />
                 </div>
                 <input
                   id="confirmPassword"
@@ -213,64 +210,62 @@ const Register = () => {
                   required
                   value={formData.confirmPassword}
                   onChange={handleChange}
-                  className={`pl-10 pr-10 w-full px-3 py-3 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent ${
-                    errors.confirmPassword ? 'border-red-300' : 'border-gray-300'
+                  className={`pl-10 pr-10 w-full px-3 py-3 border rounded-2xl focus:ring-2 focus:ring-burrow-primary focus:border-transparent bg-white/90 ${
+                    errors.confirmPassword ? 'border-red-300' : 'border-burrow-border'
                   }`}
                   placeholder="Confirm Password"
                 />
                 <button
                   type="button"
-                  className="absolute inset-y-0 right-0 pr-3 flex items-center"
+                  className="absolute inset-y-0 right-0 pr-3 flex items-center text-burrow-text-secondary"
                   onClick={() => setShowConfirmPassword(!showConfirmPassword)}
                 >
-                  {showConfirmPassword ? (
-                    <EyeOff className="h-5 w-5 text-gray-400" />
-                  ) : (
-                    <Eye className="h-5 w-5 text-gray-400" />
-                  )}
+                  {showConfirmPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
                 </button>
               </div>
               {errors.confirmPassword && <p className="text-red-600 text-xs mt-1">{errors.confirmPassword}</p>}
             </div>
           </div>
 
-          <div className="flex items-center">
-            <input
-              id="accept-terms"
-              name="accept-terms"
-              type="checkbox"
-              checked={acceptTerms}
-              onChange={(event) => setAcceptTerms(event.target.checked)}
-              className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-            />
-            <label htmlFor="accept-terms" className="ml-2 block text-sm text-gray-700">
-              I accept the{' '}
-              <Link to="/terms" className="text-blue-600 hover:text-blue-500">
-                Terms and Conditions
-              </Link>{' '}
-              and{' '}
-              <Link to="/privacy" className="text-blue-600 hover:text-blue-500">
-                Privacy Policy
-              </Link>
-            </label>
+          <div className="flex items-start">
+            <div className="flex items-center h-5">
+              <input
+                id="terms"
+                name="terms"
+                type="checkbox"
+                checked={acceptTerms}
+                onChange={(event) => setAcceptTerms(event.target.checked)}
+                className="h-4 w-4 rounded border-burrow-border text-burrow-primary focus:ring-burrow-primary"
+              />
+            </div>
+            <div className="ml-3 text-sm">
+              <label htmlFor="terms" className="font-medium text-burrow-text-primary">
+                I agree to the{' '}
+                <Link to="/terms" className="text-burrow-primary hover:text-burrow-secondary">
+                  terms and conditions
+                </Link>{' '}
+                and{' '}
+                <Link to="/privacy" className="text-burrow-primary hover:text-burrow-secondary">
+                  privacy policy
+                </Link>
+              </label>
+            </div>
           </div>
           {errors.terms && <p className="text-red-600 text-xs">{errors.terms}</p>}
 
           <button
             type="submit"
             disabled={state.isLoading}
-            className="w-full flex justify-center py-3 px-4 border border-transparent rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="burrow-button-primary w-full justify-center disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {state.isLoading ? 'Creating account...' : 'Create account'}
           </button>
 
-          <div className="text-center">
-            <p className="text-sm text-gray-600">
-              Already have an account?{' '}
-              <Link to="/login" className="text-blue-600 hover:text-blue-500 font-medium">
-                Sign in
-              </Link>
-            </p>
+          <div className="text-center text-sm text-burrow-text-secondary">
+            Already have an account?{' '}
+            <Link to="/login" className="text-burrow-primary hover:text-burrow-secondary font-medium">
+              Sign in
+            </Link>
           </div>
         </form>
       </div>

--- a/src/pages/Dashboard/ConsumerDashboard.jsx
+++ b/src/pages/Dashboard/ConsumerDashboard.jsx
@@ -70,7 +70,7 @@ const ConsumerDashboard = () => {
       case 'payment_pending':
       case 'reschedule_requested':
         return (
-          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
+          <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-burrow-accent/20 text-burrow-secondary">
             Pending
           </span>
         );
@@ -81,14 +81,10 @@ const ConsumerDashboard = () => {
       case 'in_storage':
       case 'preparing_dispatch':
       case 'out_for_delivery':
-        return (
-          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
-            In Progress
-          </span>
-        );
+        return <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-burrow-primary/15 text-burrow-primary">In Progress</span>;
       case 'delivered':
         return (
-          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+          <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-emerald-100 text-emerald-700">
             Delivered
           </span>
         );
@@ -105,72 +101,65 @@ const ConsumerDashboard = () => {
           </span>
         );
       case 'cancelled':
-        return (
-          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
-            Cancelled
-          </span>
-        );
+        return <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-neutral-200 text-neutral-700">Cancelled</span>;
       default:
-        return (
-          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
-            Unknown
-          </span>
-        );
+        return <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-neutral-200 text-neutral-700">Unknown</span>;
     }
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 py-8 page-fade">
+    <div className="min-h-screen py-12 page-fade">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="mb-8 page-fade">
-          <h1 className="text-3xl font-bold text-gray-900">Welcome back, {state.user?.name}!</h1>
-          <p className="text-gray-600 mt-1">Manage your deliveries and schedule new requests</p>
+        <div className="mb-10 page-fade">
+          <span className="burrow-chip">Dashboard</span>
+          <h1 className="text-3xl font-bold mt-4">Welcome back, {state.user?.name}!</h1>
+          <p className="text-burrow-text-secondary mt-2">Manage your deliveries and schedule new requests.</p>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8 fade-stagger">
-          <div className="bg-white rounded-lg shadow-md p-6">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-10 fade-stagger">
+          <div className="burrow-card p-6">
             <div className="flex items-center">
-              <div className="flex-shrink-0 w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center">
-                <Clock className="h-6 w-6 text-blue-500" />
+              <div className="flex-shrink-0 w-12 h-12 bg-burrow-primary/10 rounded-2xl flex items-center justify-center">
+                <Clock className="h-6 w-6 text-burrow-primary" />
               </div>
               <div className="ml-4">
-                <p className="text-sm font-medium text-gray-600">Active Requests</p>
-                <p className="text-2xl font-bold text-gray-900">{stats.active}</p>
+                <p className="text-sm font-medium text-burrow-text-secondary">Active Requests</p>
+                <p className="text-2xl font-bold">{stats.active}</p>
               </div>
             </div>
           </div>
 
-          <div className="bg-white rounded-lg shadow-md p-6">
+          <div className="burrow-card p-6">
             <div className="flex items-center">
-              <div className="flex-shrink-0 w-12 h-12 bg-yellow-100 rounded-lg flex items-center justify-center">
-                <AlertTriangle className="h-6 w-6 text-yellow-500" />
+              <div className="flex-shrink-0 w-12 h-12 bg-burrow-accent/20 rounded-2xl flex items-center justify-center">
+                <AlertTriangle className="h-6 w-6 text-burrow-secondary" />
               </div>
               <div className="ml-4">
-                <p className="text-sm font-medium text-gray-600">Pending Approval</p>
-                <p className="text-2xl font-bold text-gray-900">{stats.pending}</p>
+                <p className="text-sm font-medium text-burrow-text-secondary">Pending Approval</p>
+                <p className="text-2xl font-bold">{stats.pending}</p>
               </div>
             </div>
           </div>
 
-          <div className="bg-white rounded-lg shadow-md p-6">
+          <div className="burrow-card p-6">
             <div className="flex items-center">
-              <div className="flex-shrink-0 w-12 h-12 bg-green-100 rounded-lg flex items-center justify-center">
-                <CheckCircle className="h-6 w-6 text-green-500" />
+              <div className="flex-shrink-0 w-12 h-12 bg-emerald-100 rounded-2xl flex items-center justify-center">
+                <CheckCircle className="h-6 w-6 text-emerald-600" />
               </div>
               <div className="ml-4">
-                <p className="text-sm font-medium text-gray-600">Completed</p>
-                <p className="text-2xl font-bold text-gray-900">{stats.completed}</p>
+                <p className="text-sm font-medium text-burrow-text-secondary">Completed</p>
+                <p className="text-2xl font-bold">{stats.completed}</p>
               </div>
             </div>
           </div>
         </div>
 
-        <div className="bg-white rounded-lg shadow-md p-6 mb-8 page-fade">
-          <h2 className="text-xl font-semibold text-gray-900 mb-4">Quick Actions</h2>
+        <div className="burrow-card p-8 mb-10 page-fade">
+          <h2 className="text-xl font-semibold mb-4">Quick Actions</h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <Link
               to="/new-request"
-              className="flex items-center justify-center px-4 py-3 border border-transparent rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 transition-colors"
+              className="burrow-button-primary justify-center"
             >
               <Plus className="h-5 w-5 mr-2" />
               New Request
@@ -178,7 +167,7 @@ const ConsumerDashboard = () => {
 
             <Link
               to="/track"
-              className="flex items-center justify-center px-4 py-3 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 transition-colors"
+              className="burrow-button-ghost"
             >
               <Package className="h-5 w-5 mr-2" />
               Track Parcel
@@ -186,18 +175,18 @@ const ConsumerDashboard = () => {
           </div>
         </div>
 
-        <div className="bg-white rounded-lg shadow-md page-fade">
-          <div className="px-6 py-4 border-b border-gray-200">
-            <h2 className="text-xl font-semibold text-gray-900">Recent Requests</h2>
+        <div className="burrow-card page-fade overflow-hidden">
+          <div className="px-6 py-5 border-b border-burrow-border bg-burrow-muted/40">
+            <h2 className="text-xl font-semibold">Recent Requests</h2>
           </div>
 
-          <div className="divide-y divide-gray-200">
+          <div className="divide-y divide-burrow-border/70">
             {error && (
               <div className="px-6 py-4 text-sm text-red-600 bg-red-50 border-b border-red-100">{error}</div>
             )}
 
             {isLoading && (
-              <div className="px-6 py-4 text-sm text-gray-500">Loading your recent requests...</div>
+              <div className="px-6 py-4 text-sm text-burrow-text-secondary">Loading your recent requests...</div>
             )}
 
             {!isLoading && !error && userRequests.length > 0 ? (
@@ -206,18 +195,18 @@ const ConsumerDashboard = () => {
                   <div className="flex items-center justify-between">
                     <div className="flex-1">
                       <div className="flex items-center space-x-3">
-                        <h3 className="text-sm font-medium text-gray-900">{request.orderNumber}</h3>
+                        <h3 className="text-sm font-medium text-burrow-text-primary">{request.orderNumber}</h3>
                         {getStatusBadge(request.status)}
                       </div>
-                      <p className="text-sm text-gray-600 mt-1">{request.productDescription}</p>
-                      <p className="text-xs text-gray-500 mt-1">
+                      <p className="text-sm text-burrow-text-secondary mt-1">{request.productDescription}</p>
+                      <p className="text-xs text-burrow-text-secondary mt-1">
                         Scheduled: {request.scheduledDeliveryDate ? new Date(request.scheduledDeliveryDate).toLocaleDateString() : 'TBC'}
                         {request.deliveryTimeSlot ? ` at ${request.deliveryTimeSlot}` : ''}
                       </p>
                     </div>
 
                     <div className="flex items-center space-x-2">
-                      <Link to={`/request/${request.id}`} className="text-blue-600 hover:text-blue-500 text-sm font-medium">
+                      <Link to={`/request/${request.id}`} className="text-burrow-primary hover:text-burrow-secondary text-sm font-medium">
                         View Details
                       </Link>
                     </div>
@@ -228,12 +217,12 @@ const ConsumerDashboard = () => {
 
             {!isLoading && !error && userRequests.length === 0 && (
               <div className="px-6 py-8 text-center">
-                <Package className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-                <p className="text-gray-600">No requests yet</p>
-                <p className="text-gray-500 text-sm mt-1">Create your first delivery request to get started</p>
+                <Package className="h-12 w-12 text-burrow-primary mx-auto mb-4" />
+                <p className="text-burrow-text-primary">No requests yet</p>
+                <p className="text-burrow-text-secondary text-sm mt-1">Create your first delivery request to get started</p>
                 <Link
                   to="/new-request"
-                  className="inline-flex items-center px-4 py-2 mt-4 border border-transparent rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700"
+                  className="burrow-button-primary mt-4"
                 >
                   <Plus className="h-4 w-4 mr-2" />
                   Create Request
@@ -243,8 +232,8 @@ const ConsumerDashboard = () => {
           </div>
 
           {!isLoading && !error && userRequests.length > 5 && (
-            <div className="px-6 py-4 border-t border-gray-200 bg-gray-50">
-              <Link to="/orders" className="text-blue-600 hover:text-blue-500 text-sm font-medium">
+            <div className="px-6 py-4 border-t border-burrow-border bg-burrow-muted/40">
+              <Link to="/orders" className="text-burrow-primary hover:text-burrow-secondary text-sm font-medium">
                 View all requests →
               </Link>
             </div>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -57,87 +57,144 @@ const Home = () => {
   ];
 
   return (
-    <div className="min-h-screen bg-burrow-background page-fade">
-      <section className="bg-gradient-to-br from-burrow-background to-burrow-primary/10 py-24">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center">
-            <h1 className="text-5xl font-bold text-burrow-text-primary mb-6">
-              Take Control <span className="text-burrow-primary">of Your Deliveries</span>
-            </h1>
-            <p className="text-xl text-burrow-text-secondary mb-10 max-w-3xl mx-auto italic">
-              Reschedule anytime. Perfect for gifts, travel, or safe storage.
-            </p>
-            <button
-              onClick={handleGetStarted}
-              className="bg-burrow-primary text-white px-10 py-4 rounded-lg text-lg font-semibold hover:bg-burrow-accent transition-all inline-flex items-center space-x-3"
-            >
-              <span>Get Started</span>
-              <ArrowRight className="h-5 w-5" />
-            </button>
+    <div className="min-h-screen page-fade">
+      <section className="py-20">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="grid grid-cols-1 lg:grid-cols-[auto,360px] gap-12 items-center">
+            <div className="space-y-8">
+              <div className="flex flex-wrap items-center gap-3">
+                <span className="burrow-chip">Reschedule anytime</span>
+                <span className="burrow-chip">Perfect for gifts & travel</span>
+              </div>
+              <div>
+                <h1 className="text-5xl sm:text-6xl font-bold leading-tight">
+                  Take control of your deliveries with a warm human touch.
+                </h1>
+                <p className="mt-6 text-lg text-burrow-text-secondary max-w-xl">
+                  Burrow helps you reschedule, redirect, and safeguard every parcel. Your packages arrive exactly when and where you need them.
+                </p>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-4">
+                <button onClick={handleGetStarted} className="burrow-button-primary">
+                  Get Started
+                  <ArrowRight className="h-5 w-5" />
+                </button>
+                <button onClick={() => navigate('/login')} className="burrow-button-ghost">
+                  Login
+                </button>
+              </div>
+
+              <div className="flex flex-wrap gap-6 text-sm text-burrow-text-secondary">
+                <div>
+                  <p className="font-semibold text-burrow-text-primary">3,200+</p>
+                  <p>Deliveries rescheduled smoothly</p>
+                </div>
+                <div>
+                  <p className="font-semibold text-burrow-text-primary">99.2%</p>
+                  <p>Customer happiness score</p>
+                </div>
+              </div>
+            </div>
+
+            <div className="burrow-card relative overflow-hidden">
+              <div className="absolute -top-12 -right-10 h-40 w-40 rounded-full bg-burrow-accent/40 blur-3xl" aria-hidden />
+              <div className="absolute -bottom-16 -left-10 h-48 w-48 rounded-full bg-burrow-primary/20 blur-3xl" aria-hidden />
+              <div className="relative p-10 space-y-8">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <div className="h-12 w-12 rounded-2xl bg-burrow-primary/10 flex items-center justify-center text-2xl">
+                      🐿️
+                    </div>
+                    <div>
+                      <p className="text-sm uppercase tracking-wide text-burrow-text-secondary">Burrow Concierge</p>
+                      <h2 className="text-2xl font-semibold text-burrow-text-primary">Take Control of Your Deliveries</h2>
+                    </div>
+                  </div>
+                  <button
+                    onClick={() => navigate('/login')}
+                    className="text-sm font-semibold text-burrow-primary hover:text-burrow-secondary transition-colors"
+                  >
+                    Login
+                  </button>
+                </div>
+
+                <p className="text-burrow-text-secondary leading-relaxed">
+                  Reschedule anytime. Perfect for gifts, travel, or safe storage. Tell us when to deliver and we&apos;ll handle the rest.
+                </p>
+
+                <button onClick={handleGetStarted} className="burrow-button-primary w-full justify-between">
+                  Get Started
+                  <ArrowRight className="h-5 w-5" />
+                </button>
+
+                <div className="grid grid-cols-3 gap-3 text-xs">
+                  <div className="rounded-2xl bg-burrow-primary/10 px-4 py-3">
+                    <p className="font-semibold text-burrow-primary">Perfect Timing</p>
+                    <p className="text-burrow-text-secondary mt-1">Schedule for special occasions</p>
+                  </div>
+                  <div className="rounded-2xl bg-burrow-secondary/10 px-4 py-3">
+                    <p className="font-semibold text-burrow-secondary">Secure Storage</p>
+                    <p className="text-burrow-text-secondary mt-1">Avoid porch piracy</p>
+                  </div>
+                  <div className="rounded-2xl bg-burrow-accent/20 px-4 py-3">
+                    <p className="font-semibold text-burrow-text-primary">Flexible</p>
+                    <p className="text-burrow-text-secondary mt-1">Redirect with ease</p>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </section>
 
-      <section className="py-20 bg-gray-50">
+      <section className="py-20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
-            <h2 className="text-3xl font-bold text-burrow-text-primary mb-4">Why Choose Burrow?</h2>
+            <span className="burrow-chip">WHY CHOOSE US</span>
+            <h2 className="text-4xl font-bold text-burrow-text-primary mb-4 mt-6">Why people love Burrow</h2>
             <p className="text-lg text-burrow-text-secondary max-w-2xl mx-auto">
-              Trusted storage and flexible delivery options at your fingertips
+              Every delivery is cared for like it&apos;s our own. We combine smart logistics with thoughtful service so you never worry about your parcels again.
             </p>
           </div>
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-8 mb-16 fade-stagger">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 mb-16 fade-stagger">
             {benefits.map((benefit, idx) => (
               <div
                 key={idx}
-                className={`p-8 rounded-lg shadow-lg transition-transform transform hover:-translate-y-2 ${
-                  idx % 3 === 0
-                    ? 'bg-burrow-accent/20'
-                    : idx % 3 === 1
-                      ? 'bg-burrow-secondary/20'
-                      : 'bg-burrow-primary/20'
-                }`}
+                className="burrow-card h-full transition-transform hover:-translate-y-1"
               >
-                <div
-                  className={`text-4xl mb-4 flex items-center justify-center ${
-                    idx % 3 === 0
-                      ? 'text-burrow-accent'
-                      : idx % 3 === 1
-                        ? 'text-burrow-secondary'
-                        : 'text-burrow-primary'
-                  }`}
-                >
-                  <benefit.icon className="h-8 w-8" />
+                <div className="h-12 w-12 rounded-2xl flex items-center justify-center bg-burrow-primary/10 text-burrow-primary mb-6">
+                  <benefit.icon className="h-6 w-6" />
                 </div>
-                <h4 className="font-semibold text-burrow-text-primary mb-2 text-center">{benefit.title}</h4>
-                <p className="text-burrow-text-secondary text-sm text-center">{benefit.description}</p>
+                <h4 className="font-semibold text-burrow-text-primary mb-2">{benefit.title}</h4>
+                <p className="text-burrow-text-secondary text-sm leading-relaxed">{benefit.description}</p>
               </div>
             ))}
           </div>
 
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-start">
-            <div className="h-fit rounded-lg shadow-md overflow-hidden">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-10 items-start">
+            <div className="h-fit burrow-card overflow-hidden">
               <WarehouseMap
                 onWarehouseSelect={setSelectedWarehouse}
                 selectedWarehouseId={selectedWarehouse?.id}
               />
             </div>
 
-            <div className="flex flex-col space-y-4 max-h-[650px] overflow-y-auto fade-stagger">
+            <div className="flex flex-col space-y-4 max-h-[650px] overflow-y-auto fade-stagger pr-2">
               {warehouses.map((warehouse) => (
                 <div
                   key={warehouse.id}
-                  className={`p-6 border-2 rounded-lg cursor-pointer transition-all ${
+                  className={`p-6 border-2 rounded-2xl cursor-pointer transition-all ${
                     selectedWarehouse?.id === warehouse.id
-                      ? 'border-burrow-primary bg-burrow-primary/10 shadow-md'
-                      : 'border-gray-200 hover:border-gray-300 hover:shadow-sm'
+                      ? 'border-burrow-primary bg-white shadow-burrow-soft'
+                      : 'border-burrow-border bg-burrow-background/60 hover:border-burrow-primary/50 hover:shadow-burrow-soft'
                   }`}
                   onClick={() => setSelectedWarehouse(warehouse)}
                 >
-                  <h5 className="font-semibold text-burrow-text-primary">{warehouse.name}</h5>
+                  <h5 className="font-semibold text-burrow-text-primary text-lg">{warehouse.name}</h5>
                   <p className="text-burrow-text-secondary">{warehouse.address}</p>
-                  <div className="flex items-center gap-4 mt-2 text-xs text-burrow-text-secondary">
+                  <div className="flex items-center gap-4 mt-3 text-xs text-burrow-text-secondary">
                     <span>Capacity: {warehouse.capacity}</span>
                     <span>Hours: {warehouse.operatingHours}</span>
                   </div>
@@ -148,42 +205,45 @@ const Home = () => {
         </div>
       </section>
 
-      <section className="py-20 bg-white">
+      <section className="py-20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12">
-            <h2 className="text-3xl font-bold text-burrow-text-primary mb-4">How It Works</h2>
-            <p className="text-lg text-burrow-text-secondary">Three simple steps to take control of your deliveries</p>
+            <span className="burrow-chip">HOW IT WORKS</span>
+            <h2 className="text-4xl font-bold text-burrow-text-primary mb-4 mt-6">Three simple steps</h2>
+            <p className="text-lg text-burrow-text-secondary">From checkout to doorstep, we choreograph every moment for you.</p>
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8 fade-stagger">
             {howItWorks.map((step, index) => (
-              <div key={index} className="text-center">
-                <div className="w-20 h-20 bg-burrow-primary text-white rounded-full flex items-center justify-center text-2xl font-bold mx-auto mb-4">
+              <div key={index} className="burrow-card text-center py-12 px-10">
+                <div className="w-16 h-16 mx-auto mb-6 rounded-2xl bg-burrow-primary text-white flex items-center justify-center text-2xl font-bold">
                   {step.step}
                 </div>
                 <h3 className="text-xl font-semibold text-burrow-text-primary mb-3">{step.title}</h3>
-                <p className="text-burrow-text-secondary">{step.description}</p>
+                <p className="text-burrow-text-secondary leading-relaxed">{step.description}</p>
               </div>
             ))}
           </div>
         </div>
       </section>
 
-      <section className="py-20 bg-burrow-primary">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <h2 className="text-3xl font-bold text-white mb-4">
-            Ready to Take Control of Your Deliveries?
-          </h2>
-          <p className="text-xl text-burrow-background mb-8">
-            Join thousands of customers who trust Burrow with their packages
-          </p>
-          <button
-            onClick={handleGetStarted}
-            className="bg-white text-burrow-primary px-10 py-4 rounded-lg text-lg font-semibold hover:bg-gray-100 transition-all inline-flex items-center space-x-3"
-          >
-            <span>Get Started Today</span>
-            <ArrowRight className="h-5 w-5" />
-          </button>
+      <section className="py-20">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="burrow-card relative overflow-hidden text-center py-16 px-8">
+            <div className="absolute inset-0 bg-gradient-to-br from-burrow-primary/10 via-transparent to-burrow-secondary/10" aria-hidden />
+            <div className="relative space-y-6">
+              <h2 className="text-4xl font-bold text-burrow-text-primary">
+                Ready to take control of your deliveries?
+              </h2>
+              <p className="text-lg text-burrow-text-secondary max-w-2xl mx-auto">
+                Join thousands of happy households who trust Burrow to choreograph the perfect delivery timing.
+              </p>
+              <button onClick={handleGetStarted} className="burrow-button-primary">
+                Get Started Today
+                <ArrowRight className="h-5 w-5" />
+              </button>
+            </div>
+          </div>
         </div>
       </section>
     </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,15 +5,22 @@ export default {
     extend: {
       colors: {
         burrow: {
-          primary: '#1E3A8A',
-          secondary: '#059669',
-          accent: '#F59E0B',
-          background: '#F9FAFB',
+          primary: '#3A5BA0',
+          secondary: '#C58B4E',
+          accent: '#F0B860',
+          background: '#F7F5F8',
+          surface: '#FFFFFF',
+          border: '#E3E3E3',
+          muted: '#F4EFEA',
           text: {
-            primary: '#111827',
-            secondary: '#4B5563'
+            primary: '#2D2A32',
+            secondary: '#5F5B62'
           }
         }
+      },
+      boxShadow: {
+        burrow: '0 20px 45px -20px rgba(58, 91, 160, 0.35)',
+        'burrow-soft': '0 14px 35px -18px rgba(197, 139, 78, 0.25)'
       }
     },
   },


### PR DESCRIPTION
## Summary
- refresh the Tailwind palette with the Burrow primary, secondary, and accent tones and add shared component styles
- redesign the header, footer, home hero, and supporting sections to mirror the provided mockup aesthetic
- restyle authentication and consumer dashboard screens for a cohesive warm Burrow look and feel across the app

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3f44dcd508321b8c0e2c905bbf146