### PR TITLE
Refactor styling to shared CSS utilities

### DIFF
--- a/src/components/Layout/Footer.jsx
+++ b/src/components/Layout/Footer.jsx
@@ -4,66 +4,64 @@ import { Link } from 'react-router-dom';
 
 const Footer = () => {
   return (
-    <footer id="site-footer" className="bg-burrow-background border-t border-gray-200">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
-          <div className="col-span-1">
-            <div className="flex items-center space-x-2 mb-4">
-              <Package className="h-8 w-8 text-burrow-primary" />
-              <span className="text-2xl font-extrabold bg-gradient-to-r from-burrow-primary to-burrow-secondary bg-clip-text text-transparent tracking-tight">
-                Burrow
-              </span>
-            </div>
-            <p className="text-burrow-text-secondary text-sm">
-              Delivery rescheduling made simple. Take control of your deliveries and schedule them on your terms.
-            </p>
+    <footer id="site-footer" className="footer">
+      <div className="footer-container">
+        <div>
+          <div className="flex items-center space-x-2 mb-4">
+            <Package className="h-8 w-8 text-burrow-primary" />
+            <span className="text-2xl font-extrabold bg-gradient-to-r from-burrow-primary to-burrow-secondary bg-clip-text text-transparent tracking-tight">
+              Burrow
+            </span>
           </div>
-
-          <div>
-            <h3 className="font-semibold text-burrow-text-primary mb-4">Services</h3>
-            <ul className="space-y-2 text-sm text-burrow-text-secondary">
-              <li><Link to="/how-it-works" className="hover:text-burrow-primary transition-colors">How It Works</Link></li>
-              <li><Link to="/warehouses" className="hover:text-burrow-primary transition-colors">Warehouses</Link></li>
-              <li><Link to="/pricing" className="hover:text-burrow-primary transition-colors">Pricing</Link></li>
-              <li><Link to="/tracking" className="hover:text-burrow-primary transition-colors">Track Order</Link></li>
-            </ul>
-          </div>
-
-          <div>
-            <h3 className="font-semibold text-burrow-text-primary mb-4">Support</h3>
-            <ul className="space-y-2 text-sm text-burrow-text-secondary">
-              <li><Link to="/help" className="hover:text-burrow-primary transition-colors">Help Center</Link></li>
-              <li><Link to="/contact" className="hover:text-burrow-primary transition-colors">Contact Us</Link></li>
-              <li><Link to="/faq" className="hover:text-burrow-primary transition-colors">FAQ</Link></li>
-              <li><Link to="/terms" className="hover:text-burrow-primary transition-colors">Terms of Service</Link></li>
-            </ul>
-          </div>
-
-          <div>
-            <h3 className="font-semibold text-burrow-text-primary mb-4">Contact</h3>
-            <div className="space-y-2 text-sm text-burrow-text-secondary">
-              <div className="flex items-center space-x-2">
-                <Mail className="h-4 w-4 text-burrow-primary" />
-                <span>support@burrow.com</span>
-              </div>
-              <div className="flex items-center space-x-2">
-                <Phone className="h-4 w-4 text-burrow-primary" />
-                <span>+91 98765 43210</span>
-              </div>
-              <div className="flex items-center space-x-2">
-                <MapPin className="h-4 w-4 text-burrow-primary" />
-                <span>Mumbai, India</span>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="border-t border-gray-200 mt-8 pt-8 text-center">
-          <p className="text-sm text-burrow-text-secondary">
-            © 2024 Burrow. All rights reserved. |
-            <Link to="/privacy" className="hover:text-burrow-primary transition-colors ml-1">Privacy Policy</Link>
+          <p className="text-burrow-text-secondary text-sm">
+            Delivery rescheduling made simple. Take control of your deliveries and schedule them on your terms.
           </p>
         </div>
+
+        <div>
+          <h3 className="footer-heading">Services</h3>
+          <ul className="space-y-2 text-sm text-burrow-text-secondary">
+            <li><Link to="/how-it-works" className="footer-link">How It Works</Link></li>
+            <li><Link to="/warehouses" className="footer-link">Warehouses</Link></li>
+            <li><Link to="/pricing" className="footer-link">Pricing</Link></li>
+            <li><Link to="/tracking" className="footer-link">Track Order</Link></li>
+          </ul>
+        </div>
+
+        <div>
+          <h3 className="footer-heading">Support</h3>
+          <ul className="space-y-2 text-sm text-burrow-text-secondary">
+            <li><Link to="/help" className="footer-link">Help Center</Link></li>
+            <li><Link to="/contact" className="footer-link">Contact Us</Link></li>
+            <li><Link to="/faq" className="footer-link">FAQ</Link></li>
+            <li><Link to="/terms" className="footer-link">Terms of Service</Link></li>
+          </ul>
+        </div>
+
+        <div>
+          <h3 className="footer-heading">Contact</h3>
+          <div className="space-y-2 text-sm text-burrow-text-secondary">
+            <div className="flex items-center space-x-2">
+              <Mail className="h-4 w-4 text-burrow-primary" />
+              <span>support@burrow.com</span>
+            </div>
+            <div className="flex items-center space-x-2">
+              <Phone className="h-4 w-4 text-burrow-primary" />
+              <span>+91 98765 43210</span>
+            </div>
+            <div className="flex items-center space-x-2">
+              <MapPin className="h-4 w-4 text-burrow-primary" />
+              <span>Mumbai, India</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="layout-container border-t border-gray-200 mt-8 pt-8 text-center">
+        <p className="text-sm text-burrow-text-secondary">
+          © 2024 Burrow. All rights reserved. |
+          <Link to="/privacy" className="footer-link ml-1">Privacy Policy</Link>
+        </p>
       </div>
     </footer>
   );

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -17,7 +17,7 @@ const Header = () => {
 
   return (
     <header className="sticky top-0 z-50 bg-burrow-background shadow-sm border-b border-gray-200">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div className="layout-container">
         <div className="flex justify-between items-center h-16">
           <div className="flex items-center">
             <Link to="/" className="flex items-center space-x-2">
@@ -31,16 +31,10 @@ const Header = () => {
           <nav className="flex items-center space-x-8">
             {!state.user ? (
               <>
-                <Link
-                  to="/login"
-                  className="text-burrow-text-secondary hover:text-burrow-primary transition-colors"
-                >
+                <Link to="/login" className="nav-link">
                   Login
                 </Link>
-                <Link
-                  to="/register"
-                  className="bg-burrow-primary text-white px-4 py-2 rounded-lg hover:bg-burrow-accent transition-colors"
-                >
+                <Link to="/register" className="btn-primary btn-md">
                   Sign Up
                 </Link>
               </>
@@ -48,26 +42,17 @@ const Header = () => {
               <>
                 {!isOperatorRoute && (
                   <>
-                    <Link
-                      to="/dashboard"
-                      className="text-burrow-text-secondary hover:text-burrow-primary transition-colors"
-                    >
+                    <Link to="/dashboard" className="nav-link">
                       Dashboard
                     </Link>
-                    <Link
-                      to="/new-request"
-                      className="text-burrow-text-secondary hover:text-burrow-primary transition-colors"
-                    >
+                    <Link to="/new-request" className="nav-link">
                       New Request
                     </Link>
                   </>
                 )}
 
                 {state.user.role === 'operator' && !isOperatorRoute && (
-                  <Link
-                    to="/operator/dashboard"
-                    className="text-burrow-primary hover:text-indigo-700 transition-colors font-medium"
-                  >
+                  <Link to="/operator/dashboard" className="nav-link-strong">
                     Operator Portal
                   </Link>
                 )}
@@ -78,10 +63,7 @@ const Header = () => {
                     <span className="text-sm">{state.user.name}</span>
                   </div>
 
-                  <button
-                    onClick={handleLogout}
-                    className="flex items-center space-x-1 text-burrow-text-secondary hover:text-red-500 transition-colors"
-                  >
+                  <button onClick={handleLogout} className="btn-text-danger">
                     <LogOut className="h-4 w-4" />
                     <span className="text-sm">Logout</span>
                   </button>

--- a/src/components/Map/WarehouseMap.jsx
+++ b/src/components/Map/WarehouseMap.jsx
@@ -71,10 +71,10 @@ const WarehouseMap = ({ onWarehouseSelect, selectedWarehouseId }) => {
   }, [selectedWarehouse]);
 
   return (
-    <div className="bg-white rounded-lg shadow-md p-6">
+    <div className="map-card">
       <h3 className="text-xl font-semibold text-burrow-text-primary mb-4">Find Nearby Warehouses</h3>
 
-      <div className="bg-burrow-background rounded-lg h-64 mb-6 overflow-hidden">
+      <div className="map-shell mb-6">
         {isMapReady ? (
           <MapContainer
             center={mapCenter}
@@ -108,7 +108,7 @@ const WarehouseMap = ({ onWarehouseSelect, selectedWarehouseId }) => {
             ))}
           </MapContainer>
         ) : (
-          <div className="h-full flex flex-col items-center justify-center text-burrow-text-secondary">
+          <div className="map-placeholder">
             <MapPin className="h-10 w-10 mb-2 text-burrow-primary" />
             <p>Loading map...</p>
           </div>
@@ -116,7 +116,7 @@ const WarehouseMap = ({ onWarehouseSelect, selectedWarehouseId }) => {
       </div>
 
       <div
-        className={`rounded-lg border p-4 flex flex-col gap-2 transition-colors duration-200 ${
+        className={`card-bordered p-4 flex flex-col gap-2 transition-colors duration-200 ${
           selectedWarehouse ? 'bg-green-50 border-green-400' : 'bg-burrow-background border-burrow-primary/30'
         }`}
       >

--- a/src/components/StatusTracker/StatusTracker.jsx
+++ b/src/components/StatusTracker/StatusTracker.jsx
@@ -159,10 +159,10 @@ const StatusTracker = ({ currentStatus, statusHistory }) => {
   };
 
   return (
-    <div className="bg-white rounded-lg shadow-md p-6">
+    <div className="card-padded">
       <h3 className="text-xl font-semibold text-gray-900 mb-6">Order Status</h3>
 
-      <div className="space-y-4">
+      <div className="timeline">
         {statusOrder.map((status, index) => {
           const config = statusConfig[status];
           const Icon = config.icon;
@@ -177,12 +177,12 @@ const StatusTracker = ({ currentStatus, statusHistory }) => {
           return (
             <div
               key={status}
-              className={`flex items-start space-x-4 transition-all duration-500 ease-out ${
+              className={`timeline-item ${
                 isRevealed ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-6'
               }`}
             >
               <div
-                className={`flex-shrink-0 w-10 h-10 rounded-full flex items-center justify-center transition-all duration-500 ease-out ${
+                className={`timeline-icon ${
                   isCompleted
                     ? `${config.bgColor} shadow-sm`
                     : 'bg-gray-100'
@@ -195,9 +195,9 @@ const StatusTracker = ({ currentStatus, statusHistory }) => {
                 />
               </div>
 
-              <div className="flex-1 min-w-0">
+              <div className="timeline-content">
                 <div className="flex items-center justify-between">
-                  <p className={`text-sm font-medium ${
+                  <p className={`timeline-title ${
                     isCompleted ? 'text-gray-900' : 'text-gray-500'
                   }`}>
                     {config.label}
@@ -209,7 +209,7 @@ const StatusTracker = ({ currentStatus, statusHistory }) => {
                   </p>
 
                   {statusEntry && (
-                    <p className="text-xs text-gray-500">
+                    <p className="timeline-meta">
                       {formatTimestamp(statusEntry.timestamp)}
                     </p>
                   )}

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,5 @@
+@import './styles/components.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/src/pages/Auth/Login.jsx
+++ b/src/pages/Auth/Login.jsx
@@ -33,32 +33,32 @@ const Login = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 page-fade">
-      <div className="max-w-md w-full space-y-8">
+    <div className="auth-wrapper page-fade">
+      <div className="auth-container">
         <div className="text-center">
-          <h2 className="text-3xl font-bold text-gray-900">Welcome back</h2>
-          <p className="mt-2 text-gray-600">Sign in to your Burrow account</p>
+          <h2 className="auth-title">Welcome back</h2>
+          <p className="auth-subtitle">Sign in to your Burrow account</p>
         </div>
 
         {state.error && (
-          <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-            <p className="text-red-600 text-sm">{state.error}</p>
+          <div className="alert-error">
+            <p>{state.error}</p>
           </div>
         )}
 
-        <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-          <p className="text-blue-800 text-sm font-medium mb-2">Demo Credentials For An Operator View:</p>
+        <div className="alert-info">
+          <p className="font-medium mb-2">Demo Credentials For An Operator View:</p>
 
-          <p className="text-blue-700 text-xs">Operator 1: operator.one@burrow.com / OperatorDemo1</p>
-          <p className="text-blue-700 text-xs">Operator 2: operator.two@burrow.com / OperatorDemo2</p>
+          <p className="text-xs text-blue-700">Operator 1: operator.one@burrow.com / OperatorDemo1</p>
+          <p className="text-xs text-blue-700">Operator 2: operator.two@burrow.com / OperatorDemo2</p>
         </div>
 
         <form className="mt-8 space-y-6 fade-stagger" onSubmit={handleSubmit}>
           <div className="space-y-4 fade-stagger">
             <div>
               <label htmlFor="email" className="sr-only">Email address</label>
-              <div className="relative">
-                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+              <div className="input-group">
+                <div className="input-icon">
                   <Mail className="h-5 w-5 text-gray-400" />
                 </div>
                 <input
@@ -68,7 +68,7 @@ const Login = () => {
                   required
                   value={formData.email}
                   onChange={handleChange}
-                  className="pl-10 w-full px-3 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="input-field"
                   placeholder="Email address"
                 />
               </div>
@@ -76,8 +76,8 @@ const Login = () => {
 
             <div>
               <label htmlFor="password" className="sr-only">Password</label>
-              <div className="relative">
-                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+              <div className="input-group">
+                <div className="input-icon">
                   <Lock className="h-5 w-5 text-gray-400" />
                 </div>
                 <input
@@ -87,12 +87,12 @@ const Login = () => {
                   required
                   value={formData.password}
                   onChange={handleChange}
-                  className="pl-10 pr-10 w-full px-3 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="input-field pr-10"
                   placeholder="Password"
                 />
                 <button
                   type="button"
-                  className="absolute inset-y-0 right-0 pr-3 flex items-center"
+                  className="btn-text-muted absolute inset-y-0 right-0 pr-3"
                   onClick={() => setShowPassword(!showPassword)}
                 >
                   {showPassword ? (
@@ -121,7 +121,7 @@ const Login = () => {
             </div>
 
             <div className="text-sm">
-              <Link to="/forgot-password" className="text-blue-600 hover:text-blue-500">
+              <Link to="/forgot-password" className="nav-link">
                 Forgot password?
               </Link>
             </div>
@@ -130,15 +130,15 @@ const Login = () => {
           <button
             type="submit"
             disabled={state.isLoading}
-            className="w-full flex justify-center py-3 px-4 border border-transparent rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="btn-blue btn-block btn-md"
           >
             {state.isLoading ? 'Signing in...' : 'Sign in'}
           </button>
 
-          <div className="text-center">
-            <p className="text-sm text-gray-600">
+          <div className="auth-cta">
+            <p>
               Don&apos;t have an account?{' '}
-              <Link to="/register" className="text-blue-600 hover:text-blue-500 font-medium">
+              <Link to="/register" className="nav-link font-medium">
                 Sign up
               </Link>
             </p>

--- a/src/pages/Auth/Register.jsx
+++ b/src/pages/Auth/Register.jsx
@@ -86,16 +86,16 @@ const Register = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 page-fade">
-      <div className="max-w-md w-full space-y-8">
+    <div className="auth-wrapper page-fade">
+      <div className="auth-container">
         <div className="text-center">
-          <h2 className="text-3xl font-bold text-gray-900">Create your account</h2>
-          <p className="mt-2 text-gray-600">Join Burrow and take control of your deliveries</p>
+          <h2 className="auth-title">Create your account</h2>
+          <p className="auth-subtitle">Join Burrow and take control of your deliveries</p>
         </div>
 
         {state.error && (
-          <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-            <p className="text-red-600 text-sm">{state.error}</p>
+          <div className="alert-error">
+            <p>{state.error}</p>
           </div>
         )}
 
@@ -103,8 +103,8 @@ const Register = () => {
           <div className="space-y-4 fade-stagger">
             <div>
               <label htmlFor="name" className="sr-only">Full Name</label>
-              <div className="relative">
-                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+              <div className="input-group">
+                <div className="input-icon">
                   <User className="h-5 w-5 text-gray-400" />
                 </div>
                 <input
@@ -114,8 +114,8 @@ const Register = () => {
                   required
                   value={formData.name}
                   onChange={handleChange}
-                  className={`pl-10 w-full px-3 py-3 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent ${
-                    errors.name ? 'border-red-300' : 'border-gray-300'
+                  className={`input-field ${
+                    errors.name ? 'border-red-300 focus:border-red-400 focus:ring-red-400' : ''
                   }`}
                   placeholder="Full Name"
                 />
@@ -125,8 +125,8 @@ const Register = () => {
 
             <div>
               <label htmlFor="email" className="sr-only">Email address</label>
-              <div className="relative">
-                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+              <div className="input-group">
+                <div className="input-icon">
                   <Mail className="h-5 w-5 text-gray-400" />
                 </div>
                 <input
@@ -136,8 +136,8 @@ const Register = () => {
                   required
                   value={formData.email}
                   onChange={handleChange}
-                  className={`pl-10 w-full px-3 py-3 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent ${
-                    errors.email ? 'border-red-300' : 'border-gray-300'
+                  className={`input-field ${
+                    errors.email ? 'border-red-300 focus:border-red-400 focus:ring-red-400' : ''
                   }`}
                   placeholder="Email address"
                 />
@@ -147,8 +147,8 @@ const Register = () => {
 
             <div>
               <label htmlFor="phone" className="sr-only">Phone Number</label>
-              <div className="relative">
-                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+              <div className="input-group">
+                <div className="input-icon">
                   <Phone className="h-5 w-5 text-gray-400" />
                 </div>
                 <input
@@ -158,8 +158,8 @@ const Register = () => {
                   required
                   value={formData.phone}
                   onChange={handleChange}
-                  className={`pl-10 w-full px-3 py-3 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent ${
-                    errors.phone ? 'border-red-300' : 'border-gray-300'
+                  className={`input-field ${
+                    errors.phone ? 'border-red-300 focus:border-red-400 focus:ring-red-400' : ''
                   }`}
                   placeholder="Phone Number"
                 />
@@ -169,8 +169,8 @@ const Register = () => {
 
             <div>
               <label htmlFor="password" className="sr-only">Password</label>
-              <div className="relative">
-                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+              <div className="input-group">
+                <div className="input-icon">
                   <Lock className="h-5 w-5 text-gray-400" />
                 </div>
                 <input
@@ -180,14 +180,14 @@ const Register = () => {
                   required
                   value={formData.password}
                   onChange={handleChange}
-                  className={`pl-10 pr-10 w-full px-3 py-3 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent ${
-                    errors.password ? 'border-red-300' : 'border-gray-300'
+                  className={`input-field pr-10 ${
+                    errors.password ? 'border-red-300 focus:border-red-400 focus:ring-red-400' : ''
                   }`}
                   placeholder="Password"
                 />
                 <button
                   type="button"
-                  className="absolute inset-y-0 right-0 pr-3 flex items-center"
+                  className="btn-text-muted absolute inset-y-0 right-0 pr-3"
                   onClick={() => setShowPassword(!showPassword)}
                 >
                   {showPassword ? (
@@ -202,8 +202,8 @@ const Register = () => {
 
             <div>
               <label htmlFor="confirmPassword" className="sr-only">Confirm Password</label>
-              <div className="relative">
-                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+              <div className="input-group">
+                <div className="input-icon">
                   <Lock className="h-5 w-5 text-gray-400" />
                 </div>
                 <input
@@ -213,14 +213,14 @@ const Register = () => {
                   required
                   value={formData.confirmPassword}
                   onChange={handleChange}
-                  className={`pl-10 pr-10 w-full px-3 py-3 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent ${
-                    errors.confirmPassword ? 'border-red-300' : 'border-gray-300'
+                  className={`input-field pr-10 ${
+                    errors.confirmPassword ? 'border-red-300 focus:border-red-400 focus:ring-red-400' : ''
                   }`}
                   placeholder="Confirm Password"
                 />
                 <button
                   type="button"
-                  className="absolute inset-y-0 right-0 pr-3 flex items-center"
+                  className="btn-text-muted absolute inset-y-0 right-0 pr-3"
                   onClick={() => setShowConfirmPassword(!showConfirmPassword)}
                 >
                   {showConfirmPassword ? (
@@ -259,15 +259,15 @@ const Register = () => {
           <button
             type="submit"
             disabled={state.isLoading}
-            className="w-full flex justify-center py-3 px-4 border border-transparent rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="btn-blue btn-block btn-md"
           >
             {state.isLoading ? 'Creating account...' : 'Create account'}
           </button>
 
-          <div className="text-center">
-            <p className="text-sm text-gray-600">
+          <div className="auth-cta">
+            <p>
               Already have an account?{' '}
-              <Link to="/login" className="text-blue-600 hover:text-blue-500 font-medium">
+              <Link to="/login" className="nav-link font-medium">
                 Sign in
               </Link>
             </p>

--- a/src/pages/Dashboard/ConsumerDashboard.jsx
+++ b/src/pages/Dashboard/ConsumerDashboard.jsx
@@ -121,14 +121,14 @@ const ConsumerDashboard = () => {
 
   return (
     <div className="min-h-screen bg-gray-50 py-8 page-fade">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div className="layout-container">
         <div className="mb-8 page-fade">
           <h1 className="text-3xl font-bold text-gray-900">Welcome back, {state.user?.name}!</h1>
           <p className="text-gray-600 mt-1">Manage your deliveries and schedule new requests</p>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8 fade-stagger">
-          <div className="bg-white rounded-lg shadow-md p-6">
+        <div className="stats-grid mb-8 fade-stagger">
+          <div className="stat-card">
             <div className="flex items-center">
               <div className="flex-shrink-0 w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center">
                 <Clock className="h-6 w-6 text-blue-500" />
@@ -140,7 +140,7 @@ const ConsumerDashboard = () => {
             </div>
           </div>
 
-          <div className="bg-white rounded-lg shadow-md p-6">
+          <div className="stat-card">
             <div className="flex items-center">
               <div className="flex-shrink-0 w-12 h-12 bg-yellow-100 rounded-lg flex items-center justify-center">
                 <AlertTriangle className="h-6 w-6 text-yellow-500" />
@@ -152,7 +152,7 @@ const ConsumerDashboard = () => {
             </div>
           </div>
 
-          <div className="bg-white rounded-lg shadow-md p-6">
+          <div className="stat-card">
             <div className="flex items-center">
               <div className="flex-shrink-0 w-12 h-12 bg-green-100 rounded-lg flex items-center justify-center">
                 <CheckCircle className="h-6 w-6 text-green-500" />
@@ -165,12 +165,12 @@ const ConsumerDashboard = () => {
           </div>
         </div>
 
-        <div className="bg-white rounded-lg shadow-md p-6 mb-8 page-fade">
+        <div className="card-padded mb-8 page-fade">
           <h2 className="text-xl font-semibold text-gray-900 mb-4">Quick Actions</h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <Link
               to="/new-request"
-              className="flex items-center justify-center px-4 py-3 border border-transparent rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 transition-colors"
+              className="btn-blue btn-md"
             >
               <Plus className="h-5 w-5 mr-2" />
               New Request
@@ -178,7 +178,7 @@ const ConsumerDashboard = () => {
 
             <Link
               to="/track"
-              className="flex items-center justify-center px-4 py-3 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 transition-colors"
+              className="btn-neutral btn-md"
             >
               <Package className="h-5 w-5 mr-2" />
               Track Parcel
@@ -186,7 +186,7 @@ const ConsumerDashboard = () => {
           </div>
         </div>
 
-        <div className="bg-white rounded-lg shadow-md page-fade">
+        <div className="card page-fade">
           <div className="px-6 py-4 border-b border-gray-200">
             <h2 className="text-xl font-semibold text-gray-900">Recent Requests</h2>
           </div>
@@ -217,7 +217,7 @@ const ConsumerDashboard = () => {
                     </div>
 
                     <div className="flex items-center space-x-2">
-                      <Link to={`/request/${request.id}`} className="text-blue-600 hover:text-blue-500 text-sm font-medium">
+                      <Link to={`/request/${request.id}`} className="nav-link font-medium text-sm">
                         View Details
                       </Link>
                     </div>
@@ -233,7 +233,7 @@ const ConsumerDashboard = () => {
                 <p className="text-gray-500 text-sm mt-1">Create your first delivery request to get started</p>
                 <Link
                   to="/new-request"
-                  className="inline-flex items-center px-4 py-2 mt-4 border border-transparent rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700"
+                  className="btn-blue btn-md mt-4"
                 >
                   <Plus className="h-4 w-4 mr-2" />
                   Create Request
@@ -244,7 +244,7 @@ const ConsumerDashboard = () => {
 
           {!isLoading && !error && userRequests.length > 5 && (
             <div className="px-6 py-4 border-t border-gray-200 bg-gray-50">
-              <Link to="/orders" className="text-blue-600 hover:text-blue-500 text-sm font-medium">
+              <Link to="/orders" className="nav-link font-medium text-sm">
                 View all requests →
               </Link>
             </div>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -58,8 +58,8 @@ const Home = () => {
 
   return (
     <div className="min-h-screen bg-burrow-background page-fade">
-      <section className="bg-gradient-to-br from-burrow-background to-burrow-primary/10 py-24">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <section className="section-hero">
+        <div className="layout-container">
           <div className="text-center">
             <h1 className="text-5xl font-bold text-burrow-text-primary mb-6">
               Take Control <span className="text-burrow-primary">of Your Deliveries</span>
@@ -69,7 +69,7 @@ const Home = () => {
             </p>
             <button
               onClick={handleGetStarted}
-              className="bg-burrow-primary text-white px-10 py-4 rounded-lg text-lg font-semibold hover:bg-burrow-accent transition-all inline-flex items-center space-x-3"
+              className="btn-primary btn-lg"
             >
               <span>Get Started</span>
               <ArrowRight className="h-5 w-5" />
@@ -78,11 +78,11 @@ const Home = () => {
         </div>
       </section>
 
-      <section className="py-20 bg-gray-50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-16">
-            <h2 className="text-3xl font-bold text-burrow-text-primary mb-4">Why Choose Burrow?</h2>
-            <p className="text-lg text-burrow-text-secondary max-w-2xl mx-auto">
+      <section className="section-muted">
+        <div className="layout-container">
+          <div className="section-heading">
+            <h2 className="section-heading-title mb-4">Why Choose Burrow?</h2>
+            <p className="section-heading-subtitle max-w-2xl mx-auto">
               Trusted storage and flexible delivery options at your fingertips
             </p>
           </div>
@@ -91,7 +91,7 @@ const Home = () => {
             {benefits.map((benefit, idx) => (
               <div
                 key={idx}
-                className={`p-8 rounded-lg shadow-lg transition-transform transform hover:-translate-y-2 ${
+                className={`feature-card ${
                   idx % 3 === 0
                     ? 'bg-burrow-accent/20'
                     : idx % 3 === 1
@@ -100,7 +100,7 @@ const Home = () => {
                 }`}
               >
                 <div
-                  className={`text-4xl mb-4 flex items-center justify-center ${
+                  className={`feature-icon ${
                     idx % 3 === 0
                       ? 'text-burrow-accent'
                       : idx % 3 === 1
@@ -117,21 +117,21 @@ const Home = () => {
           </div>
 
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-start">
-            <div className="h-fit rounded-lg shadow-md overflow-hidden">
+            <div className="card overflow-hidden">
               <WarehouseMap
                 onWarehouseSelect={setSelectedWarehouse}
                 selectedWarehouseId={selectedWarehouse?.id}
               />
             </div>
 
-            <div className="flex flex-col space-y-4 max-h-[650px] overflow-y-auto fade-stagger">
+            <div className="list-panel fade-stagger">
               {warehouses.map((warehouse) => (
                 <div
                   key={warehouse.id}
-                  className={`p-6 border-2 rounded-lg cursor-pointer transition-all ${
+                  className={`list-card ${
                     selectedWarehouse?.id === warehouse.id
-                      ? 'border-burrow-primary bg-burrow-primary/10 shadow-md'
-                      : 'border-gray-200 hover:border-gray-300 hover:shadow-sm'
+                      ? 'list-card-active'
+                      : 'list-card-inactive'
                   }`}
                   onClick={() => setSelectedWarehouse(warehouse)}
                 >
@@ -148,11 +148,11 @@ const Home = () => {
         </div>
       </section>
 
-      <section className="py-20 bg-white">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-12">
-            <h2 className="text-3xl font-bold text-burrow-text-primary mb-4">How It Works</h2>
-            <p className="text-lg text-burrow-text-secondary">Three simple steps to take control of your deliveries</p>
+      <section className="section-white">
+        <div className="layout-container">
+          <div className="section-heading">
+            <h2 className="section-heading-title mb-4">How It Works</h2>
+            <p className="section-heading-subtitle">Three simple steps to take control of your deliveries</p>
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8 fade-stagger">
@@ -169,8 +169,8 @@ const Home = () => {
         </div>
       </section>
 
-      <section className="py-20 bg-burrow-primary">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+      <section className="section-primary">
+        <div className="layout-container text-center">
           <h2 className="text-3xl font-bold text-white mb-4">
             Ready to Take Control of Your Deliveries?
           </h2>
@@ -179,7 +179,7 @@ const Home = () => {
           </p>
           <button
             onClick={handleGetStarted}
-            className="bg-white text-burrow-primary px-10 py-4 rounded-lg text-lg font-semibold hover:bg-gray-100 transition-all inline-flex items-center space-x-3"
+            className="btn-secondary btn-lg"
           >
             <span>Get Started Today</span>
             <ArrowRight className="h-5 w-5" />

--- a/src/pages/Request/TrackRequest.jsx
+++ b/src/pages/Request/TrackRequest.jsx
@@ -153,8 +153,8 @@ const TrackRequest = () => {
 
   return (
     <div className="bg-gray-50 min-h-full py-12 page-fade">
-      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="bg-white shadow-md rounded-lg p-8 page-fade">
+      <div className="layout-container-narrow">
+        <div className="card-panel page-fade">
           <h1 className="text-2xl font-bold text-gray-900 mb-2">Track your delivery request</h1>
           <p className="text-sm text-gray-600 mb-6">
             Enter your order number to view the current status, scheduled date, and destination details of your request.
@@ -162,18 +162,18 @@ const TrackRequest = () => {
 
           <form onSubmit={handleSubmit} className="space-y-4 fade-stagger">
             <div>
-              <label htmlFor="orderNumber" className="block text-sm font-medium text-gray-700">
+              <label htmlFor="orderNumber" className="form-label">
                 Order number
               </label>
               <div className="mt-2 flex flex-col gap-3 sm:grid sm:grid-cols-[1fr_auto] sm:items-center">
-                <div className="relative sm:max-w-none">
-                  <div className="pointer-events-none absolute inset-y-0 left-0 pl-3 flex items-center">
+                <div className="input-group sm:max-w-none">
+                  <div className="input-icon">
                     <Search className="h-5 w-5 text-gray-400" />
                   </div>
                   <input
                     id="orderNumber"
                     type="text"
-                    className="block w-full rounded-lg border border-gray-300 bg-white py-3 pl-11 pr-4 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                    className="input-field"
                     placeholder="e.g. BRW-2458"
                     value={orderNumber}
                     onChange={(event) => setOrderNumber(event.target.value)}
@@ -181,7 +181,7 @@ const TrackRequest = () => {
                 </div>
                 <button
                   type="submit"
-                  className="inline-flex h-12 w-full items-center justify-center rounded-lg border border-transparent bg-blue-600 px-6 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-60 disabled:hover:bg-blue-600 sm:h-full sm:w-auto"
+                  className="btn-blue btn-md sm:h-full sm:w-auto"
                   disabled={isSearching}
                 >
                   {isSearching ? 'Searching...' : 'Track'}
@@ -191,7 +191,7 @@ const TrackRequest = () => {
           </form>
 
           {error && (
-            <div className="mt-6 flex items-center rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
+            <div className="alert-error mt-6">
               <AlertCircle className="h-5 w-5 mr-2" />
               <span>{error}</span>
             </div>

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1,0 +1,309 @@
+@layer components {
+  .layout-container {
+    @apply mx-auto max-w-7xl px-4 sm:px-6 lg:px-8;
+  }
+
+  .layout-container-narrow {
+    @apply mx-auto max-w-3xl px-4 sm:px-6 lg:px-8;
+  }
+
+  .section-hero {
+    @apply bg-gradient-to-br from-burrow-background to-burrow-primary/10 py-24;
+  }
+
+  .section-muted {
+    @apply bg-gray-50 py-20;
+  }
+
+  .section-white {
+    @apply bg-white py-20;
+  }
+
+  .section-primary {
+    @apply bg-burrow-primary py-20;
+  }
+
+  .section-heading {
+    @apply mb-12 text-center;
+  }
+
+  .section-heading-title {
+    @apply text-3xl font-bold text-burrow-text-primary;
+  }
+
+  .section-heading-subtitle {
+    @apply text-lg text-burrow-text-secondary;
+  }
+
+  .card {
+    @apply rounded-lg bg-white shadow-md;
+  }
+
+  .card-bordered {
+    @apply card border border-gray-200;
+  }
+
+  .card-panel {
+    @apply card p-8;
+  }
+
+  .card-padded {
+    @apply card p-6;
+  }
+
+  .card-stats {
+    @apply card p-6;
+  }
+
+  .feature-card {
+    @apply rounded-lg p-8 shadow-lg transform transition-transform duration-200 hover:-translate-y-2;
+  }
+
+  .feature-icon {
+    @apply mb-4 flex items-center justify-center text-4xl;
+  }
+
+  .map-card {
+    @apply card p-6;
+  }
+
+  .map-shell {
+    @apply h-64 overflow-hidden rounded-lg bg-burrow-background;
+  }
+
+  .map-placeholder {
+    @apply flex h-full flex-col items-center justify-center text-burrow-text-secondary;
+  }
+
+  .list-panel {
+    @apply flex max-h-[650px] flex-col space-y-4 overflow-y-auto;
+  }
+
+  .list-card {
+    @apply cursor-pointer rounded-lg border-2 p-6 transition-all;
+  }
+
+  .list-card-active {
+    @apply border-burrow-primary bg-burrow-primary/10 shadow-md;
+  }
+
+  .list-card-inactive {
+    @apply border-gray-200 hover:border-gray-300 hover:shadow-sm;
+  }
+
+  .btn {
+    @apply inline-flex items-center justify-center gap-2 rounded-lg font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50;
+  }
+
+  .btn-block {
+    @apply w-full;
+  }
+
+  .btn-lg {
+    @apply px-10 py-4 text-lg;
+  }
+
+  .btn-md {
+    @apply px-6 py-3 text-sm;
+  }
+
+  .btn-sm {
+    @apply px-4 py-2 text-xs;
+  }
+
+  .btn-primary {
+    @apply btn bg-burrow-primary text-white hover:bg-burrow-accent focus:ring-burrow-primary;
+  }
+
+  .btn-secondary {
+    @apply btn bg-white text-burrow-primary hover:bg-gray-100 focus:ring-burrow-primary;
+  }
+
+  .btn-neutral {
+    @apply btn border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 focus:ring-gray-300;
+  }
+
+  .btn-blue {
+    @apply btn bg-blue-600 text-white hover:bg-blue-700 focus:ring-blue-500;
+  }
+
+  .btn-light {
+    @apply btn text-burrow-text-secondary hover:text-burrow-primary focus:ring-transparent;
+  }
+
+  .btn-danger {
+    @apply btn text-red-600 hover:text-red-500 focus:ring-red-500;
+  }
+
+  .btn-text {
+    @apply inline-flex items-center gap-2 text-sm font-medium transition-colors;
+  }
+
+  .btn-text-muted {
+    @apply btn-text text-burrow-text-secondary hover:text-burrow-primary;
+  }
+
+  .btn-text-danger {
+    @apply btn-text text-burrow-text-secondary hover:text-red-500;
+  }
+
+  .nav-link {
+    @apply text-burrow-text-secondary transition-colors hover:text-burrow-primary;
+  }
+
+  .nav-link-strong {
+    @apply font-medium text-burrow-primary transition-colors hover:text-indigo-700;
+  }
+
+  .input-group {
+    @apply relative;
+  }
+
+  .input-icon {
+    @apply pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-gray-400;
+  }
+
+  .input-field {
+    @apply w-full rounded-lg border border-gray-300 bg-white py-3 pl-10 pr-4 text-sm text-gray-900 shadow-sm focus:border-burrow-primary focus:ring-burrow-primary;
+  }
+
+  .input-field-plain {
+    @apply w-full rounded-lg border border-gray-300 bg-white py-3 px-4 text-sm text-gray-900 shadow-sm focus:border-burrow-primary focus:ring-burrow-primary;
+  }
+
+  .form-label {
+    @apply block text-sm font-medium text-gray-700;
+  }
+
+  .form-helper {
+    @apply text-xs text-gray-500;
+  }
+
+  .form-error {
+    @apply mt-2 text-sm text-red-600;
+  }
+
+  .alert {
+    @apply rounded-lg border px-4 py-3 text-sm;
+  }
+
+  .alert-error {
+    @apply alert border-red-200 bg-red-50 text-red-700;
+  }
+
+  .alert-info {
+    @apply alert border-blue-200 bg-blue-50 text-blue-700;
+  }
+
+  .empty-state {
+    @apply rounded-lg border border-gray-200 bg-gray-50 p-8 text-center text-sm text-gray-600;
+  }
+
+  .table-wrapper {
+    @apply overflow-hidden rounded-lg border border-gray-200 shadow-sm;
+  }
+
+  .table {
+    @apply min-w-full divide-y divide-gray-200;
+  }
+
+  .table-head {
+    @apply bg-gray-50;
+  }
+
+  .table-head-cell {
+    @apply px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500;
+  }
+
+  .table-row {
+    @apply bg-white transition-colors hover:bg-gray-50;
+  }
+
+  .table-cell {
+    @apply whitespace-nowrap px-6 py-4 text-sm text-gray-700;
+  }
+
+  .stats-grid {
+    @apply grid grid-cols-1 gap-6 md:grid-cols-4;
+  }
+
+  .stat-card {
+    @apply card p-6;
+  }
+
+  .dashboard-section {
+    @apply space-y-6;
+  }
+
+  .dashboard-heading {
+    @apply text-xl font-semibold text-gray-900;
+  }
+
+  .dashboard-subheading {
+    @apply text-sm text-gray-500;
+  }
+
+  .timeline {
+    @apply space-y-4;
+  }
+
+  .timeline-item {
+    @apply flex items-start space-x-4 transition-all duration-500 ease-out;
+  }
+
+  .timeline-icon {
+    @apply flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full transition-all duration-500;
+  }
+
+  .timeline-content {
+    @apply min-w-0 flex-1;
+  }
+
+  .timeline-title {
+    @apply text-sm font-medium text-gray-900;
+  }
+
+  .timeline-meta {
+    @apply mt-1 text-xs text-gray-500;
+  }
+
+  .footer {
+    @apply border-t border-gray-200 bg-burrow-background;
+  }
+
+  .footer-container {
+    @apply layout-container grid grid-cols-1 gap-12 py-12 md:grid-cols-4;
+  }
+
+  .footer-heading {
+    @apply text-sm font-semibold uppercase tracking-wide text-burrow-text-secondary;
+  }
+
+  .footer-link {
+    @apply text-sm text-burrow-text-secondary transition-colors hover:text-burrow-primary;
+  }
+
+  .auth-wrapper {
+    @apply flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8;
+  }
+
+  .auth-container {
+    @apply w-full max-w-md space-y-8;
+  }
+
+  .auth-card {
+    @apply card space-y-6 p-8;
+  }
+
+  .auth-title {
+    @apply text-center text-3xl font-bold text-gray-900;
+  }
+
+  .auth-subtitle {
+    @apply mt-2 text-center text-gray-600;
+  }
+
+  .auth-cta {
+    @apply text-center text-sm text-gray-600;
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable Tailwind component layer in `components.css` and import it globally
- refactor key layout components and pages to use the new shared classes instead of long inline utility lists
- standardize authentication, dashboard, and tracking forms on the shared button and input styles for easier future theming

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3fda60e9c8321889d18d45a0905a3