### PR TITLE
Allow operators to open uploaded receipt PDFs

### DIFF
--- a/server/routes/deliveryRequests.js
+++ b/server/routes/deliveryRequests.js
@@ -24,6 +24,9 @@ const STATUS_FLOW = [
   'cancelled'
 ];
 
+const MAX_RECEIPT_SIZE = 5 * 1024 * 1024;
+const PDF_DATA_URL_PREFIX = 'data:application/pdf;base64,';
+
 function buildStatusHistoryEntry(status, note) {
   return {
     status,
@@ -39,6 +42,94 @@ function parseDate(value, fieldName) {
   }
 
   return date;
+}
+
+function sanitiseReceipt(receipt) {
+  if (!receipt || typeof receipt !== 'object') {
+    throw new Error('receipt is required.');
+  }
+
+  const { fileName, fileSize, mimeType, data } = receipt;
+
+  if (!fileName || !fileName.trim()) {
+    throw new Error('receipt.fileName is required.');
+  }
+
+  if (!mimeType || !mimeType.trim()) {
+    throw new Error('receipt.mimeType is required.');
+  }
+
+  if (mimeType !== 'application/pdf') {
+    throw new Error('receipt must be a PDF document.');
+  }
+
+  if (fileSize === undefined || fileSize === null) {
+    throw new Error('receipt.fileSize is required.');
+  }
+
+  const numericSize = Number(fileSize);
+
+  if (!Number.isFinite(numericSize) || numericSize <= 0) {
+    throw new Error('receipt.fileSize must be a positive number.');
+  }
+
+  if (numericSize > MAX_RECEIPT_SIZE) {
+    throw new Error('receipt exceeds the 5MB size limit.');
+  }
+
+  if (data === undefined || data === null) {
+    throw new Error('receipt.data is required.');
+  }
+
+  if (typeof data !== 'string') {
+    throw new Error('receipt.data must be a base64-encoded data URL.');
+  }
+
+  const trimmedData = data.trim();
+
+  if (!trimmedData) {
+    throw new Error('receipt.data must be a base64-encoded data URL.');
+  }
+
+  const commaIndex = trimmedData.indexOf(',');
+
+  if (commaIndex === -1) {
+    throw new Error('receipt.data must contain a valid base64 payload.');
+  }
+
+  const prefix = trimmedData.slice(0, commaIndex).toLowerCase();
+  const base64Payload = trimmedData.slice(commaIndex + 1).replace(/\s+/g, '');
+
+  if (!prefix.startsWith('data:application/pdf;base64')) {
+    throw new Error('receipt.data must be a base64-encoded PDF document.');
+  }
+
+  if (!base64Payload) {
+    throw new Error('receipt.data must contain a valid base64 payload.');
+  }
+
+  let buffer;
+  try {
+    buffer = Buffer.from(base64Payload, 'base64');
+  } catch (error) {
+    const invalidBase64 = new Error('receipt.data must contain valid base64-encoded content.');
+    invalidBase64.cause = error;
+    throw invalidBase64;
+  }
+
+  if (!buffer?.byteLength) {
+    throw new Error('receipt.data must contain valid base64-encoded content.');
+  }
+
+  const normalisedDataUrl = `${PDF_DATA_URL_PREFIX}${buffer.toString('base64')}`;
+
+  return {
+    fileName: fileName.trim(),
+    fileSize: Math.round(numericSize),
+    mimeType: mimeType.trim(),
+    uploadedAt: new Date(),
+    data: normalisedDataUrl
+  };
 }
 
 function ensureDatabase(req, res) {
@@ -155,6 +246,7 @@ router.post('/', async (req, res) => {
     scheduledDeliveryDate,
     deliveryTimeSlot,
     destinationAddress,
+    receipt,
     paymentDetails = {}
   } = req.body ?? {};
 
@@ -206,6 +298,13 @@ router.post('/', async (req, res) => {
     }
   }
 
+  let sanitisedReceipt;
+  try {
+    sanitisedReceipt = sanitiseReceipt(receipt);
+  } catch (error) {
+    return res.status(400).json({ message: error.message });
+  }
+
   const now = new Date();
 
   const request = {
@@ -229,6 +328,7 @@ router.post('/', async (req, res) => {
       paymentStatus: paymentDetails.paymentStatus ?? 'pending',
       paymentMethod: paymentDetails.paymentMethod ?? 'card'
     },
+    receipt: sanitisedReceipt,
     createdAt: now,
     updatedAt: now
   };

--- a/src/pages/Operator/OperatorDashboard.jsx
+++ b/src/pages/Operator/OperatorDashboard.jsx
@@ -3,6 +3,46 @@ import { Search, Filter, Eye, CheckCircle, XCircle, Clock } from 'lucide-react';
 
 import apiClient from '../../lib/api';
 
+const buildReceiptUrl = (receipt) => {
+  if (!receipt || typeof receipt !== 'object') {
+    return null;
+  }
+
+  const data = typeof receipt.data === 'string' ? receipt.data.trim() : '';
+
+  if (!data) {
+    return null;
+  }
+
+  if (data.startsWith('data:')) {
+    return data;
+  }
+
+  const mimeType = receipt.mimeType?.trim() || 'application/pdf';
+  return `data:${mimeType};base64,${data}`;
+};
+
+const formatFileSize = (bytes) => {
+  const numeric = Number(bytes);
+
+  if (!Number.isFinite(numeric) || numeric < 0) {
+    return '';
+  }
+
+  if (numeric < 1024) {
+    return `${numeric} B`;
+  }
+
+  const kb = numeric / 1024;
+
+  if (kb < 1024) {
+    return `${kb.toFixed(1)} KB`;
+  }
+
+  const mb = kb / 1024;
+  return `${mb.toFixed(2)} MB`;
+};
+
 const OperatorDashboard = () => {
   const [searchTerm, setSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
@@ -163,6 +203,8 @@ const OperatorDashboard = () => {
     setModalNotes('');
     setUpdateError(null);
   };
+
+  const receiptUrl = buildReceiptUrl(selectedRequest?.receipt);
 
   return (
     <div className="min-h-screen bg-burrow-background page-fade">
@@ -393,6 +435,55 @@ const OperatorDashboard = () => {
                       <span className="text-burrow-text-secondary">Product:</span>
                       <span className="font-medium text-burrow-text-primary">{selectedRequest.productDescription}</span>
                     </div>
+                  </div>
+                </div>
+
+                <div>
+                  <h4 className="font-medium text-burrow-text-primary mb-2">Receipt</h4>
+                  <div className="bg-burrow-background rounded-xl p-4 space-y-3">
+                    {selectedRequest.receipt ? (
+                      <>
+                        <div className="flex justify-between">
+                          <span className="text-burrow-text-secondary">File Name:</span>
+                          <span className="font-medium text-burrow-text-primary truncate max-w-xs">
+                            {selectedRequest.receipt.fileName}
+                          </span>
+                        </div>
+                        <div className="flex justify-between">
+                          <span className="text-burrow-text-secondary">File Size:</span>
+                          <span className="font-medium text-burrow-text-primary">
+                            {formatFileSize(selectedRequest.receipt.fileSize) || '—'}
+                          </span>
+                        </div>
+                        <div className="flex justify-between">
+                          <span className="text-burrow-text-secondary">Uploaded:</span>
+                          <span className="font-medium text-burrow-text-primary">
+                            {selectedRequest.receipt.uploadedAt
+                              ? new Date(selectedRequest.receipt.uploadedAt).toLocaleString()
+                              : '—'}
+                          </span>
+                        </div>
+                        {receiptUrl ? (
+                          <div className="pt-3 border-t border-burrow-border/60 flex justify-end">
+                            <a
+                              href={receiptUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="btn-secondary btn-sm"
+                              download={selectedRequest.receipt.fileName || 'receipt.pdf'}
+                            >
+                              View Receipt (PDF)
+                            </a>
+                          </div>
+                        ) : (
+                          <p className="text-sm text-burrow-text-muted">
+                            Receipt file is unavailable.
+                          </p>
+                        )}
+                      </>
+                    ) : (
+                      <p className="text-sm text-burrow-text-muted">No receipt was provided.</p>
+                    )}
                   </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- persist the base64-encoded receipt data alongside metadata when requests are saved
- ensure the new request wizard reads the receipt PDF into a data URL before submission
- expose receipt metadata and a PDF viewer link within the operator dashboard modal

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ea03aaadd8832199caf832e74cbf4f