### PR TITLE
Adjust hero layout with squirrel illustration

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { Clock, Shield, MapPin, Calendar, ArrowRight } from 'lucide-react';
 import WarehouseMap from '../components/Map/WarehouseMap';
 import { warehouses } from '../data/mockData';
+import squirrelImage from '../../assets/squirrel.png';
 
 const Home = () => {
   const navigate = useNavigate();
@@ -60,20 +61,27 @@ const Home = () => {
     <div className="min-h-screen bg-burrow-background page-fade">
       <section className="section-hero">
         <div className="layout-container">
-          <div className="text-center">
-            <h1 className="text-5xl font-bold text-burrow-text-primary mb-6">
-              Take Control <span className="text-burrow-primary">of Your Deliveries</span>
-            </h1>
-            <p className="text-xl text-burrow-text-secondary mb-10 max-w-3xl mx-auto italic">
-              Reschedule anytime. Perfect for gifts, travel, or safe storage.
-            </p>
-            <button
-              onClick={handleGetStarted}
-              className="btn-primary btn-lg"
-            >
-              <span>Get Started</span>
-              <ArrowRight className="h-5 w-5" />
-            </button>
+          <div className="flex flex-col-reverse items-center gap-10 md:flex-row md:items-center">
+            <div className="text-center md:text-left md:w-1/2">
+              <h1 className="text-5xl font-bold text-burrow-text-primary mb-6">
+                Take Control <span className="text-burrow-primary">of Your Deliveries</span>
+              </h1>
+              <p className="text-xl text-burrow-text-secondary mb-10 max-w-3xl mx-auto italic md:mx-0">
+                Reschedule anytime. Perfect for gifts, travel, or safe storage.
+              </p>
+              <button
+                onClick={handleGetStarted}
+                className="btn-primary btn-lg"
+              >
+                <span>Get Started</span>
+                <ArrowRight className="h-5 w-5" />
+              </button>
+            </div>
+            <img
+              src={squirrelImage}
+              alt="Friendly delivery squirrel"
+              className="w-48 md:w-64 lg:w-72 object-contain md:ml-auto"
+            />
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- shift the hero content into a split layout so the copy reads left-aligned on larger screens while staying centered on mobile
- add the squirrel image asset to the hero section to reinforce the playful styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ea1ebf33a0832194a7158fa5a78b95