### PR TITLE
Fix password reveal toggle duplication and correct footer tracking link

### DIFF
--- a/src/components/Layout/Footer.jsx
+++ b/src/components/Layout/Footer.jsx
@@ -22,7 +22,7 @@ const Footer = () => {
             <li><Link to="/how-it-works" className="footer-link">How It Works</Link></li>
             <li><Link to="/warehouses" className="footer-link">Warehouses</Link></li>
             <li><Link to="/pricing" className="footer-link">Pricing</Link></li>
-            <li><Link to="/tracking" className="footer-link">Track Order</Link></li>
+            <li><Link to="/track" className="footer-link">Track Order</Link></li>
           </ul>
         </div>
 

--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,16 @@
     @apply bg-burrow-background text-burrow-text-primary antialiased;
   }
 
+  input[type='password']::-ms-reveal,
+  input[type='password']::-ms-clear {
+    display: none;
+  }
+
+  input[type='password']::-webkit-credentials-auto-fill-button {
+    visibility: hidden;
+    display: none;
+  }
+
   ::selection {
     @apply bg-burrow-primary text-burrow-text-inverse;
   }


### PR DESCRIPTION
## Summary
- hide the browser-provided password reveal control so only the custom eye toggle is displayed
- update the footer's "Track Order" link to route to the authenticated tracking page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ea3b279d2c8321add191ff791e427c